### PR TITLE
HEAT Curve Rework

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -91,11 +91,13 @@ do -- ACF global vars
 	ACF.HEATEfficiency     = 0.5     -- Efficiency of converting explosive energy to velocity
 	ACF.LinerThicknessMult = 0.04   -- Metal liner thickness multiplier
 	ACF.MaxChargeHeadLen   = 1.2     -- Maximum shaped charge head length (in charge diameters), lengths above will incur diminishing returns
-	ACF.HEATPenMul         = 0.85    -- Linear jet penetration multiplier
+	ACF.HEATPenMul         = 0.85 * 8    -- Linear jet penetration multiplier
 	ACF.HEATMinPenVel      = 1000    -- m/s, minimum velocity of the copper jet that contributes to penetration
 	ACF.HEATCavityMul      = 1.2     -- Size of the penetration cavity in penetrator volume expended
 	ACF.HEATSpallingArc    = 0.5     -- Cossine of the HEAT spalling angle
 	ACF.HEATBoomConvert    = 1 / 3   -- Percentage of filler that creates HE damage at detonation
+	ACF.HEATStandOffMul = 0.11 -- Percentage of standoff to use in penetration calculation (Original was too hig)
+	ACF.HEATBreakUpMul = 0.15 -- Percentage of breakup time to use in penetration calculation (Original was too high)
 
 	-- Material densities
 	ACF.SteelDensity       = 7.9e-3  -- kg/cm^3

--- a/lua/acf/entities/ammo_types/heat.lua
+++ b/lua/acf/entities/ammo_types/heat.lua
@@ -110,10 +110,10 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local JetAvgVel  = (2 * FillerEnergy / JetMass) ^ 0.5  -- Average velocity of the copper jet
 	local JetMinVel  = JetAvgVel * MinVelMult              -- Minimum velocity of the jet (the rear)
 	-- Calculates the maximum velocity, considering the velocity distribution is linear from the rear to the tip (integrated this by hand, pain :) )
-	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) * ACF.HEATBreakUpMul -- Maximum velocity of the jet (the tip)
+	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) -- Maximum velocity of the jet (the tip)
 
 	-- Both the "magic numbers" are unitless, tuning constants that were used to fit the breakup time to real world values, I suggest they not be messed with
-	local BreakupTime    = 1.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333  -- Jet breakup time in seconds
+	local BreakupTime    = 1.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333 * ACF.HEATBreakUpMul -- Jet breakup time in seconds
 	local BreakupDist    = JetMaxVel * BreakupTime
 
 	GUIData.MinConeAng = MinConeAng
@@ -161,6 +161,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 		Data.JetMinVel     = _JetMinVel
 		Data.JetMaxVel     = _JetMaxVel
 	end
+
 	for K, V in pairs(self:GetDisplayData(Data)) do
 		GUIData[K] = V
 	end

--- a/lua/acf/entities/ammo_types/heat.lua
+++ b/lua/acf/entities/ammo_types/heat.lua
@@ -40,8 +40,7 @@ function Ammo:GetPenetration(Bullet, Standoff)
 	local BreakupT      = Bullet.BreakupTime
 	local MaxVel        = Bullet.JetMaxVel
 	local PenMul        = Bullet.PenMul or 1
-	local TargetDensity = ACF.RHADensity -- Assuming RHA
-	local Gamma         = math.sqrt(TargetDensity / ACF.CopperDensity)
+	local Gamma         = 1 --math.sqrt(TargetDensity / ACF.CopperDensity) (Set to 1 to maintain continuity)
 
 	local Penetration = 0
 	if Standoff < Bullet.BreakupDist then
@@ -82,7 +81,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local BodyLength      = Data.ProjLength - CapLength
 	local FreeVol, FreeLength, FreeRadius = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, BodyLength)
 	-- Considering most of the cap gets crushed (early HEAT suffered from this)
-	local Standoff        = (0.3 * CapLength + FreeLength * ToolData.StandoffRatio) * 1e-2 -- cm to m
+	local Standoff        = (0.3 * CapLength + FreeLength * ToolData.StandoffRatio) * 1e-2 * ACF.HEATStandOffMul -- cm to m
 	local WarheadVol      = FreeVol * (1 - ToolData.StandoffRatio)
 	local WarheadLength   = FreeLength * (1 - ToolData.StandoffRatio)
 	local WarheadDiameter = 2 * FreeRadius
@@ -111,7 +110,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local JetAvgVel  = (2 * FillerEnergy / JetMass) ^ 0.5  -- Average velocity of the copper jet
 	local JetMinVel  = JetAvgVel * MinVelMult              -- Minimum velocity of the jet (the rear)
 	-- Calculates the maximum velocity, considering the velocity distribution is linear from the rear to the tip (integrated this by hand, pain :) )
-	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) -- Maximum velocity of the jet (the tip)
+	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) * ACF.HEATBreakUpMul -- Maximum velocity of the jet (the tip)
 
 	-- Both the "magic numbers" are unitless, tuning constants that were used to fit the breakup time to real world values, I suggest they not be messed with
 	local BreakupTime    = 1.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333  -- Jet breakup time in seconds
@@ -141,7 +140,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	-- Recalculate the standoff for missiles
 	if Data.MissileStandoff then
-		Data.Standoff = (FreeLength * ToolData.StandoffRatio + Data.MissileStandoff) * 1e-2
+		Data.Standoff = (FreeLength * ToolData.StandoffRatio + Data.MissileStandoff) * 1e-2 * ACF.HEATStandOffMul
 	end
 	-- God weeped when this spaghetto was written (for missile roundinject)
 	if Data.FillerMul or Data.LinerMassMul then
@@ -156,7 +155,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 		local _JetAvgVel    = (2 * _FillerEnergy / _JetMass) ^ 0.5
 		local _JetMinVel    = _JetAvgVel * _MinVelMult
 		local _JetMaxVel    = 0.5 * (3 ^ 0.5 * (8 * _FillerEnergy - _JetMass * _JetMinVel ^ 2) ^ 0.5 / _JetMass ^ 0.5 - JetMinVel)
-		Data.BreakupTime   = 1.6e-6 * (5e9 * _JetMass / (_JetMaxVel - _JetMinVel)) ^ 0.3333
+		Data.BreakupTime   = 1.6e-6 * (5e9 * _JetMass / (_JetMaxVel - _JetMinVel)) ^ 0.3333 * ACF.HEATBreakUpMul
 		Data.BreakupDist   = _JetMaxVel * Data.BreakupTime
 		Data.JetMass       = _JetMass
 		Data.JetMinVel     = _JetMinVel

--- a/lua/acf/entities/ammo_types/heatfs.lua
+++ b/lua/acf/entities/ammo_types/heatfs.lua
@@ -25,7 +25,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local CapLength       = GUIData.MinProjLength * 0.5
 	local BodyLength      = Data.ProjLength - CapLength
 	local FreeVol, FreeLength, FreeRadius = ACF.RoundShellCapacity(Data.PropMass, Data.ProjArea, Data.Caliber, BodyLength)
-	local Standoff        = (CapLength + FreeLength * ToolData.StandoffRatio) * 1e-2 -- cm to m
+	local Standoff        = (CapLength + FreeLength * ToolData.StandoffRatio) * 1e-2 * ACF.HEATStandOffMul-- cm to m
 	local WarheadVol      = FreeVol * (1 - ToolData.StandoffRatio)
 	local WarheadLength   = FreeLength * (1 - ToolData.StandoffRatio)
 	local WarheadDiameter = 2 * FreeRadius
@@ -57,7 +57,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	local JetMaxVel  = 0.5 * (3 ^ 0.5 * (8 * FillerEnergy - JetMass * JetMinVel ^ 2) ^ 0.5 / JetMass ^ 0.5 - JetMinVel) -- Maximum velocity of the jet (the tip)
 
 	-- Both the "magic numbers" are unitless, tuning constants that were used to fit the breakup time to real world values, I suggest they not be messed with
-	local BreakupTime    = 2.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333  -- Jet breakup time in seconds
+	local BreakupTime    = 2.6e-6 * (5e9 * JetMass / (JetMaxVel - JetMinVel)) ^ 0.3333 * ACF.HEATBreakUpMul  -- Jet breakup time in seconds
 	local BreakupDist    = JetMaxVel * BreakupTime
 
 	GUIData.MinConeAng = MinConeAng
@@ -84,7 +84,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 
 	-- Recalculate the standoff for missiles
 	if Data.MissileStandoff then
-		Data.Standoff = (FreeLength * ToolData.StandoffRatio + Data.MissileStandoff) * 1e-2
+		Data.Standoff = (FreeLength * ToolData.StandoffRatio + Data.MissileStandoff) * 1e-2 * ACF.HEATStandOffMul
 	end
 	-- God weeped when this spaghetto was written (for missile roundinject)
 	if Data.FillerMul or Data.LinerMassMul then
@@ -99,7 +99,7 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 		local _JetAvgVel    = (2 * _FillerEnergy / _JetMass) ^ 0.5
 		local _JetMinVel    = _JetAvgVel * _MinVelMult
 		local _JetMaxVel    = 0.5 * (3 ^ 0.5 * (8 * _FillerEnergy - _JetMass * _JetMinVel ^ 2) ^ 0.5 / _JetMass ^ 0.5 - JetMinVel)
-		Data.BreakupTime   = 1.6e-6 * (5e9 * _JetMass / (_JetMaxVel - _JetMinVel)) ^ 0.3333
+		Data.BreakupTime   = 1.6e-6 * (5e9 * _JetMass / (_JetMaxVel - _JetMinVel)) ^ 0.3333 * ACF.HEATBreakUpMul
 		Data.BreakupDist   = _JetMaxVel * Data.BreakupTime
 		Data.JetMass       = _JetMass
 		Data.JetMinVel     = _JetMinVel


### PR DESCRIPTION
Reworked how HEAT curves are calculated.

- ACF Shaped Charges have had peak standoffs considerably further than what is realistic (up to 16x in some cases). 
 - For Missile APS systems, triggering an ATGM's warhead would be useless since the ATGM would retain penetration to vary far distances.
 - The primary cause was that the breakup time was also excessively long. 
 - Curve parameters have been adjusted so as to mostly match pre change passive and peak standoffs. 

List of important changes:
- Gamma set to 1 in HEAT calculations so that curves are now continuous
- Breakup time scaled to more realistic values, resulting in peak standoff being more realistic. Penmul and passive standoff adjusted to account for this.