### PR TITLE
Improved sound replacer menu for ACF3

### DIFF
--- a/lua/weapons/gmod_tool/stools/acfsound.lua
+++ b/lua/weapons/gmod_tool/stools/acfsound.lua
@@ -6,9 +6,22 @@ TOOL.ConfigName = ""
 TOOL.ClientConVar["pitch"] = "1"
 
 if CLIENT then
+
+	TOOL.Information = {
+
+		{ name = "left", icon = "gui/lmb.png" },
+		{ name = "right", icon = "gui/rmb.png" },
+		{ name = "reload", icon = "gui/r.png" },
+
+	}
+
 	language.Add("Tool.acfsound.name", "ACF Sound Replacer")
-	language.Add("Tool.acfsound.desc", "Change sound of guns/engines.")
-	language.Add("Tool.acfsound.0", "Left click to apply sound. Right click to copy sound. Reload to set default sound. Use an empty sound path to disable sound.")
+	language.Add("Tool.acfsound.desc", "Change sound of the ACF entities.")
+
+	language.Add( "Tool.acfsound.left", "Apply the new sound. You can use empty sounds too." )
+	language.Add( "Tool.acfsound.right", "Copy the sound." )
+	language.Add( "Tool.acfsound.reload", "Reset to default sound." )
+
 end
 
 ACF.SoundToolSupport = ACF.SoundToolSupport or {}
@@ -160,81 +173,127 @@ function TOOL:Reload(trace)
 	return true
 end
 
-function TOOL.BuildCPanel(panel)
-	local wide = panel:GetWide()
-	local SoundNameText = vgui.Create("DTextEntry", ValuePanel)
-	SoundNameText:SetText("")
-	SoundNameText:SetWide(wide)
-	SoundNameText:SetTall(20)
-	SoundNameText:SetMultiline(false)
-	SoundNameText:SetConVar("wire_soundemitter_sound")
-	SoundNameText:SetVisible(true)
-	panel:AddItem(SoundNameText)
-	local SoundBrowserButton = vgui.Create("DButton")
-	SoundBrowserButton:SetText("Open Sound Browser")
-	SoundBrowserButton:SetWide(wide)
-	SoundBrowserButton:SetTall(20)
-	SoundBrowserButton:SetVisible(true)
+if CLIENT then
 
-	SoundBrowserButton.DoClick = function()
-		RunConsoleCommand("wire_sound_browser_open", SoundNameText:GetValue())
+	function TOOL.BuildCPanel(panel)
+		local wide = panel:GetWide()
+
+		local Desc = panel:Help( "Replace default sounds of certain ACF entities with this tool.\n" )
+		Desc:SetFont("ACF_Control")
+
+		local SoundNameText = vgui.Create("DTextEntry", ValuePanel)
+		SoundNameText:SetText("")
+		SoundNameText:SetWide(wide - 20)
+		SoundNameText:SetTall(20)
+		SoundNameText:SetMultiline(false)
+		SoundNameText:SetConVar("wire_soundemitter_sound")
+		SoundNameText:SetVisible(true)
+		SoundNameText:Dock(LEFT)
+		panel:AddItem(SoundNameText)
+
+		local SoundBrowserButton = vgui.Create("DButton")
+		SoundBrowserButton:SetText("Open Sound Browser")
+		SoundBrowserButton:SetFont("ACF_Control")
+		SoundBrowserButton:SetWide(wide)
+		SoundBrowserButton:SetTall(20)
+		SoundBrowserButton:SetVisible(true)
+		SoundBrowserButton:SetIcon( "icon16/application_view_list.png" )
+		SoundBrowserButton.DoClick = function()
+			RunConsoleCommand("wire_sound_browser_open", SoundNameText:GetValue(), "1")
+		end
+		panel:AddItem(SoundBrowserButton)
+
+		local SoundPre = vgui.Create("DPanel")
+		SoundPre:SetWide(wide)
+		SoundPre:SetTall(20)
+		SoundPre:SetVisible(true)
+
+		local SoundPrePlay = vgui.Create("DButton", SoundPre)
+		SoundPrePlay:SetText("Play")
+		SoundPrePlay:SetFont("ACF_Control")
+		SoundPrePlay:SetVisible(true)
+		SoundPrePlay:SetIcon( "icon16/sound.png" )
+		SoundPrePlay.DoClick = function()
+			RunConsoleCommand("play",SoundNameText:GetValue())
+		end
+
+		local SoundPreStop = vgui.Create("DButton", SoundPre)
+		SoundPreStop:SetText("Stop")
+		SoundPreStop:SetFont("ACF_Control")
+		SoundPreStop:SetVisible(true)
+		SoundPreStop:SetIcon( "icon16/sound_mute.png" )
+		SoundPreStop.DoClick = function()
+			RunConsoleCommand("play", "common/NULL.WAV") --Playing a silent sound will mute the preview but not the sound emitters.
+		end
+		panel:AddItem(SoundPre)
+
+		-- Set the Play/Stop button positions here
+		SoundPre:InvalidateLayout(true)
+		SoundPre.PerformLayout = function()
+			local HWide = SoundPre:GetWide() / 2
+			local Tall = SoundPre:GetTall()
+			SoundPrePlay:SetSize(HWide, Tall)
+			SoundPrePlay:Dock(LEFT)
+
+			SoundPreStop:SetSize(Tall, Tall)
+			SoundPreStop:Dock(FILL)
+		end
+
+		local CopyButton = vgui.Create("DButton")
+		CopyButton:SetText("Copy to clipboard")
+		CopyButton:SetFont("ACF_Control")
+		CopyButton:SetWide(wide)
+		CopyButton:SetTall(20)
+		CopyButton:SetIcon( "icon16/page_copy.png" )
+		CopyButton:SetVisible(true)
+		CopyButton.DoClick = function()
+			SetClipboardText( SoundNameText:GetValue())
+		end
+		panel:AddItem(CopyButton)
+
+		local ClearButton = vgui.Create("DButton")
+		ClearButton:SetText("Clear Sound")
+		ClearButton:SetFont("ACF_Control")
+		ClearButton:SetWide(wide)
+		ClearButton:SetTall(20)
+		ClearButton:SetIcon( "icon16/cancel.png" )
+		ClearButton:SetVisible(true)
+		ClearButton.DoClick = function()
+			SoundNameText:SetValue("")
+			RunConsoleCommand("wire_soundemitter_sound", "")
+		end
+		panel:AddItem(ClearButton)
+
+		panel:NumSlider( "Pitch", "acfsound_pitch", 0.1, 2.55, 2 )
+
+		panel:ControlHelp( "Adjust the pitch of the sound. Currently supports engines only." )
 	end
 
-	panel:AddItem(SoundBrowserButton)
-	local SoundPre = vgui.Create("DPanel")
-	SoundPre:SetWide(wide)
-	SoundPre:SetTall(20)
-	SoundPre:SetVisible(true)
-	local SoundPreWide = SoundPre:GetWide()
-	local SoundPrePlay = vgui.Create("DButton", SoundPre)
-	SoundPrePlay:SetText("Play")
-	SoundPrePlay:SetWide(SoundPreWide / 2)
-	SoundPrePlay:SetPos(0, 0)
-	SoundPrePlay:SetTall(20)
-	SoundPrePlay:SetVisible(true)
-
-	SoundPrePlay.DoClick = function()
-		RunConsoleCommand("play", SoundNameText:GetValue())
-	end
-
-	local SoundPreStop = vgui.Create("DButton", SoundPre)
-	SoundPreStop:SetText("Stop")
-	SoundPreStop:SetWide(SoundPreWide / 2)
-	SoundPreStop:SetPos(SoundPreWide / 2, 0)
-	SoundPreStop:SetTall(20)
-	SoundPreStop:SetVisible(true)
-
-	SoundPreStop.DoClick = function()
-		RunConsoleCommand("play", "common/NULL.wav") --Playing a silent sound will mute the preview but not the sound emitters.
-	end
-
-	panel:AddItem(SoundPre)
-	SoundPre:InvalidateLayout(true)
-
-	SoundPre.PerformLayout = function()
-		local SPW = SoundPre:GetWide()
-		SoundPrePlay:SetWide(SPW / 2)
-		SoundPreStop:SetWide(SPW / 2)
-		SoundPreStop:SetPos(SPW / 2, 0)
-	end
-
-	panel:AddControl("Slider", {
-		Label = "Pitch:",
-		Command = "acfsound_pitch",
-		Type = "Float",
-		Min = "0.1",
-		Max = "2"
-	}):SetTooltip("Works only for engines.")
 	--[[
-	local SoundPitch = vgui.Create("DNumSlider")
-	SoundPitch:SetMin( 0.1 )
-	SoundPitch:SetMax( 2 )
-	SoundPitch:SetDecimals( 0.1 )
-	SoundPitch:SetWide(wide)
-	SoundPitch:SetText("Pitch:")
-	SoundPitch:SetToolTip("Works only for engines")
-	SoundPitch:SetConVar( "acfsound_pitch" )
-	SoundPitch:SetValue( 1 )
-	panel:AddItem(SoundPitch)
+		This is another dirty hack that prevents the sound emitter tool from automatically equipping when a sound is selected in the sound browser.
+		However, this hack only applies if the currently equipped tool is the sound replacer and you're trying to switch to the wire sound tool.
+		Additionally, if you're using a weapon instead of a tool and you choose a sound while the sound replacer menu is displayed, you will be redirected to it.
+
+		The sound emitter will be equipped normally when switching to any other tool at the time of the change.
 	]]
+
+	spawnmenu.ActivateToolLegacy = spawnmenu.ActivateToolLegacy or spawnmenu.ActivateTool
+
+	function spawnmenu.ActivateTool( tool, bool_menu, ... )
+
+		local CurTool = LocalPlayer():GetTool()
+
+		if CurTool and CurTool.Mode then
+
+			local CurMode = isstring(CurTool.Mode) and CurTool.Mode or ""
+
+			if tool == "wire_soundemitter" and CurMode == "acfsound" then
+				tool = CurMode
+			end
+
+		end
+
+		spawnmenu.ActivateToolLegacy( tool, bool_menu, ... )
+	end
+
 end


### PR DESCRIPTION
So, this is the sound menu i did for ACE, but adapted for ACF3. With this, you can:

- Quickly pick a sound from the sound menu, directly into the tool. No more pesky clicks and ctrl+v operations!
- Clear the sound bar with one button.
- Copy the sound in a simple click.
- Done visible the slider purpose. I think no one could notice it. (meant for engines)
- a minor but also important: a noice, non boring, new sound interface, with ACF3 fonts included.

Preview:
![image](https://github.com/ACF-Team/ACF-3/assets/57878680/763c348a-7ffd-48a7-ad98-3df56a239d58)


Notes:

- This was literally a 1 minute integration, with truly minor changes other than visuals and namings. Feel free to report any issue you could potentially find. For me, the sound replacer works fine.
- To avoid the sound emitter from equipping, i had to hack one of the gmod functions. The only but vague case where this could affect is when you want to switch from the sound replacer to the sound emitter in one click (which i dunno it was a big concern, at least with how i saw on ACE).