### PR TITLE
Fix ACF.GlobalFilter

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -66,6 +66,7 @@ do -- ACF global vars
 		npc_strider = true,
 		npc_dog = true,
 		phys_bone_follower = true,
+		acf_armor = not ACF.AllowProcArmor, -- Procedural armor filter
 	}
 
 	-- Ammo

--- a/lua/acf/core/utilities/traces_sh.lua
+++ b/lua/acf/core/utilities/traces_sh.lua
@@ -56,7 +56,8 @@ do -- ACF.trace
 
 		util.TraceLine(traceData)
 
-		if Output.HitNonWorld and ACF.CheckClips(Output.Entity, Output.HitPos) then
+		-- Check for clips or to filter this entity
+		if Output.HitNonWorld and (ACF.CheckClips(Output.Entity, Output.HitPos) or ACF.GlobalFilter[Output.Entity:GetClass()]) then
 			local OldFilter = traceData.filter
 			local Filter    = { Output.Entity }
 

--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -23,7 +23,7 @@ function Damage.isValidTarget(Entity)
 	local Type = ACF.Check(Entity)
 
 	if not Type then return false end
-	if GlobalFilter[Entity:GetClass()] then print(Entity) return false end
+	if GlobalFilter[Entity:GetClass()] then return false end
 	if Entity.Exploding then return false end
 	if Type ~= "Squishy" then return true end
 

--- a/lua/acf/damage/explosion_sv.lua
+++ b/lua/acf/damage/explosion_sv.lua
@@ -14,6 +14,7 @@ local TraceData    = {
 	filter = true,
 	mask   = MASK_SOLID,
 }
+local GlobalFilter = ACF.GlobalFilter
 
 --- Checks whether an entity can be affected by ACF explosions.
 -- @param Entity The entity to be checked.
@@ -22,6 +23,7 @@ function Damage.isValidTarget(Entity)
 	local Type = ACF.Check(Entity)
 
 	if not Type then return false end
+	if GlobalFilter[Entity:GetClass()] then print(Entity) return false end
 	if Entity.Exploding then return false end
 	if Type ~= "Squishy" then return true end
 

--- a/lua/acf/menu/data_callbacks.lua
+++ b/lua/acf/menu/data_callbacks.lua
@@ -187,6 +187,7 @@ local Settings = {
 
 		ACF.AllowProcArmor = Bool
 		GlobalFilter["acf_armor"] = not Bool
+		if GlobalFilter["acf_armor"] == true then print("globalfiler parmor") end
 
 		if CLIENT and not IsValid(Player) then return end
 

--- a/lua/acf/menu/data_callbacks.lua
+++ b/lua/acf/menu/data_callbacks.lua
@@ -187,7 +187,7 @@ local Settings = {
 
 		ACF.AllowProcArmor = Bool
 		GlobalFilter["acf_armor"] = not Bool
-		
+
 		if CLIENT and not IsValid(Player) then return end
 
 		Message("Info", "Procedural armor has been " .. (Bool and "enabled." or "disabled."))

--- a/lua/acf/menu/data_callbacks.lua
+++ b/lua/acf/menu/data_callbacks.lua
@@ -187,8 +187,7 @@ local Settings = {
 
 		ACF.AllowProcArmor = Bool
 		GlobalFilter["acf_armor"] = not Bool
-		if GlobalFilter["acf_armor"] == true then print("globalfiler parmor") end
-
+		
 		if CLIENT and not IsValid(Player) then return end
 
 		Message("Info", "Procedural armor has been " .. (Bool and "enabled." or "disabled."))


### PR DESCRIPTION
The ACF global filter table was not previously applied to non ballistic traces (HEAT jets or HE traces). This update should hopefully fix that.

In addition, procedural armor was meant to be filtered as per (https://github.com/ACF-Team/ACF-3/pull/355/commits/ad913041e759476b28ca48e1a59e7d81cb07bc63) but the filter was only set when changing the setting. It will be now.