### PR TITLE
Add seat model check

### DIFF
--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -47,7 +47,7 @@ hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
         Entity.ACF = {}
         Entity.ACF.PhysObj = PhysObj
         Entity.ACF.LegalMass = PhysObj:GetMass()
-        Entity.ACF.Model = Entity:GetModel()
+        Entity.ACF.Model = Entity.VehicleTable.Model or Entity:GetModel()
         Entity.ACF.LegalSeat = true
         Entity.WireDebugName = Entity.WireDebugName or Entity.VehicleTable.Name or "ACF Legal Vehicle"
 
@@ -70,7 +70,12 @@ hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
 end)
 
 hook.Add("ACF_IsLegal", "ACF_CheckLegal_SeatLegality", function(Entity)
-    if ACF.VehicleLegalChecks and Entity:IsVehicle() and not ValidSeatModels[Entity:GetModel()] then
+    if not ACF.VehicleLegalChecks then return end
+    if not Entity:IsVehicle() then return end
+
+    local ModelPath = Entity:GetModel()
+
+    if not ValidSeatModels[ModelPath] and ModelPath ~= Entity.VehicleTable.Model then
         return false, "Bad Seat Model", "This seat model is not on the whitelist."
     end
 end)

--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -3,35 +3,37 @@
 -- A whitelist of allowed seats, prevents setting your seat to something with a microscopic physics object
 local ValidSeatModels = {
     -- Default HL2 seats
-	["models/nova/airboat_seat.mdl"] = true,
-	["models/nova/chair_office02.mdl"] = true,
-	["models/props_phx/carseat2.mdl"] = true,
-	["models/props_phx/carseat2.mdl"] = true,
-	["models/props_phx/carseat3.mdl"] = true,
-	["models/props_phx/carseat2.mdl"] = true,
-	["models/nova/chair_plastic01.mdl"] = true,
-	["models/nova/jeep_seat.mdl"] = true,
-	["models/nova/chair_office01.mdl"] = true,
-	["models/nova/chair_wood01.mdl"] = true,
-	["models/vehicles/prisoner_pod_inner.mdl"] = true,
+    ["models/nova/airboat_seat.mdl"] = true,
+    ["models/nova/chair_office02.mdl"] = true,
+    ["models/props_phx/carseat2.mdl"] = true,
+    ["models/props_phx/carseat2.mdl"] = true,
+    ["models/props_phx/carseat3.mdl"] = true,
+    ["models/props_phx/carseat2.mdl"] = true,
+    ["models/nova/chair_plastic01.mdl"] = true,
+    ["models/nova/jeep_seat.mdl"] = true,
+    ["models/nova/chair_office01.mdl"] = true,
+    ["models/nova/chair_wood01.mdl"] = true,
+    ["models/vehicles/prisoner_pod_inner.mdl"] = true,
 
     -- ACF default seats
-	["models/vehicles/driver_pod.mdl"] = true,
-	["models/vehicles/pilot_seat.mdl"] = true,
+    ["models/vehicles/driver_pod.mdl"] = true,
+    ["models/vehicles/pilot_seat.mdl"] = true,
 
     -- Playerstart seats
-	["models/chairs_playerstart/airboatpose.mdl"] = true,
-	["models/chairs_playerstart/jeeppose.mdl"] = true,
-	["models/chairs_playerstart/podpose.mdl"] = true,
-	["models/chairs_playerstart/sitposealt.mdl"] = true,
-	["models/chairs_playerstart/pronepose.mdl"] = true,
-	["models/chairs_playerstart/sitpose.mdl"] = true,
-	["models/chairs_playerstart/standingpose.mdl"] = true,
-	
+    ["models/chairs_playerstart/airboatpose.mdl"] = true,
+    ["models/chairs_playerstart/jeeppose.mdl"] = true,
+    ["models/chairs_playerstart/podpose.mdl"] = true,
+    ["models/chairs_playerstart/sitposealt.mdl"] = true,
+    ["models/chairs_playerstart/pronepose.mdl"] = true,
+    ["models/chairs_playerstart/sitpose.mdl"] = true,
+    ["models/chairs_playerstart/standingpose.mdl"] = true,
+
     -- Racing seats
-	["models/lubprops/seat/raceseat.mdl"] = true,
-	["models/lubprops/seat/raceseat2.mdl"] = true,
+    ["models/lubprops/seat/raceseat.mdl"] = true,
+    ["models/lubprops/seat/raceseat2.mdl"] = true,
 }
+
+ACF.ValidSeatModels = ValidSeatModels
 
 hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
     timer.Simple(0, function()
@@ -68,8 +70,8 @@ hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
 end)
 
 hook.Add("ACF_IsLegal", "ACF_CheckLegal_SeatLegality", function(Entity)
-    if ACF.VehicleLegalChecks and Entity:IsVehicle() and not ValidSeatModels[Entity:GetModel()] then 
-        return false, "Bad Seat Model", "This seat model is not on the whitelist." 
+    if ACF.VehicleLegalChecks and Entity:IsVehicle() and not ValidSeatModels[Entity:GetModel()] then
+        return false, "Bad Seat Model", "This seat model is not on the whitelist."
     end
 end)
 

--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -1,5 +1,36 @@
 -- Optional functionality for legality checking on all vehicles
 
+-- A whitelist of allowed seats, prevents setting your seat to something with a microscopic physics object
+local ValidSeatModels = {
+    -- Default HL2 seats
+	["models/nova/airboat_seat.mdl"] = true,
+	["models/nova/chair_office02.mdl"] = true,
+	["models/props_phx/carseat2.mdl"] = true,
+	["models/props_phx/carseat2.mdl"] = true,
+	["models/props_phx/carseat3.mdl"] = true,
+	["models/props_phx/carseat2.mdl"] = true,
+	["models/nova/chair_plastic01.mdl"] = true,
+	["models/nova/jeep_seat.mdl"] = true,
+	["models/nova/chair_office01.mdl"] = true,
+	["models/nova/chair_wood01.mdl"] = true,
+	["models/vehicles/prisoner_pod_inner.mdl"] = true,
+
+    -- ACF default seats
+	["models/vehicles/driver_pod.mdl"] = true,
+	["models/vehicles/pilot_seat.mdl"] = true,
+
+	["models/chairs_playerstart/airboatpose.mdl"] = true,
+	["models/chairs_playerstart/jeeppose.mdl"] = true,
+	["models/chairs_playerstart/podpose.mdl"] = true,
+	["models/chairs_playerstart/sitposealt.mdl"] = true,
+	["models/chairs_playerstart/pronepose.mdl"] = true,
+	["models/chairs_playerstart/sitpose.mdl"] = true,
+	["models/chairs_playerstart/standingpose.mdl"] = true,
+	
+	["models/lubprops/seat/raceseat.mdl"] = true,
+	["models/lubprops/seat/raceseat2.mdl"] = true,
+}
+
 hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
     timer.Simple(0, function()
         if not IsValid(Entity) then return end
@@ -32,6 +63,12 @@ hook.Add("OnEntityCreated", "ACF_SeatLegality", function(Entity)
 
         ACF.CheckLegal(Entity)
     end)
+end)
+
+hook.Add("ACF_IsLegal", "ACF_CheckLegal_SeatLegality", function(Entity)
+    if ACF.VehicleLegalChecks and Entity:IsVehicle() and not ValidSeatModels[Entity:GetModel()] then 
+        return false, "Bad Seat Model", "This seat model is not on the whitelist." 
+    end
 end)
 
 hook.Add("CanPlayerEnterVehicle", "ACF_SeatLegality", function(Player, Entity)

--- a/lua/acf/contraption/seats_sv.lua
+++ b/lua/acf/contraption/seats_sv.lua
@@ -19,6 +19,7 @@ local ValidSeatModels = {
 	["models/vehicles/driver_pod.mdl"] = true,
 	["models/vehicles/pilot_seat.mdl"] = true,
 
+    -- Playerstart seats
 	["models/chairs_playerstart/airboatpose.mdl"] = true,
 	["models/chairs_playerstart/jeeppose.mdl"] = true,
 	["models/chairs_playerstart/podpose.mdl"] = true,
@@ -27,6 +28,7 @@ local ValidSeatModels = {
 	["models/chairs_playerstart/sitpose.mdl"] = true,
 	["models/chairs_playerstart/standingpose.mdl"] = true,
 	
+    -- Racing seats
 	["models/lubprops/seat/raceseat.mdl"] = true,
 	["models/lubprops/seat/raceseat2.mdl"] = true,
 }

--- a/lua/tests/acf/core/validation_sv/is_legal.lua
+++ b/lua/tests/acf/core/validation_sv/is_legal.lua
@@ -19,6 +19,10 @@ return {
                 return true
             end,
 
+            IsVehicle = function()
+                return false
+            end,
+
             GetCollisionGroup = function()
                 return COLLISION_GROUP_NONE
             end


### PR DESCRIPTION
Currently, seat models can be anything, including microscopic models (such as Wiremod's "nano_compare" gate). I've seen this exploited in the real world to get very hard to kill seats. 

This adds a seat model whitelist to only allow default HL2, ACF, playerstart and racing seat models.

You can see a wooden chair vs. a nano compare in terms of size:
![nano_compare_vs_wooden_chair](https://github.com/ACF-Team/ACF-3/assets/106459595/23555c6a-0781-49fb-8f43-e14742eeba30)
