### PR TITLE
Pass the targeted player into the ACF_PreBeginScanning hook call

### DIFF
--- a/lua/acf/scanner/scanner_sh.lua
+++ b/lua/acf/scanner/scanner_sh.lua
@@ -225,7 +225,7 @@ if SERVER then
     function scanning.BeginScanning(playerScanning, targetPlayer)
         if not IsValid(playerScanning) then return end
         if not IsValid(targetPlayer) then scanning.EndScanning() return end
-        if hook.Run("ACF_PreBeginScanning", playerScanning) == false then return end
+        if hook.Run("ACF_PreBeginScanning", playerScanning, targetPlayer) == false then return end
         if playerScanning:InVehicle() then return end
 
         scanningPlayers[playerScanning] = {
@@ -863,7 +863,7 @@ if CLIENT then
         if LocalPlayer():InVehicle() then
             Derma_Message("You cannot scan a target while being in a vehicle. Exit the vehicle, then try again.", "Scanning Blocked", "OK")
         return end
-        local canScan, whyNot = hook.Run("ACF_PreBeginScanning", LocalPlayer())
+        local canScan, whyNot = hook.Run("ACF_PreBeginScanning", LocalPlayer(), target)
         if not canScan then
             Derma_Message("Scanning has been blocked by the server: " .. (whyNot or "<no reason provided>"), "Scanning Blocked", "OK")
         return end


### PR DESCRIPTION
Passes the player being targeted to the hook that is run to check if we're allowed to scan. This will allow servers more control and filtering over what the player is allowed to scan since the feature can be very intrusive.