### PR TITLE
Add damage blocking & cooldown for scanner

### DIFF
--- a/lua/acf/scanner/scanner_sh.lua
+++ b/lua/acf/scanner/scanner_sh.lua
@@ -237,7 +237,14 @@ if SERVER then
 
             if started == true or (now - started < scanner_damageCooldown) then
                 if not doNotNotify then
-                    ACF.SendNotify(owner, false, started == true and "ACF damage is currently blocked due to current use of the contraption scanner." or "ACF damage is currently blocked due to recent use of the contraption scanner. Please try again in " .. math.Round(scanner_damageCooldown - (now - started), 2) .. " seconds.")
+                    local msg
+                    if started then
+                        msg = "ACF damage is currently blocked due to current use of the contraption scanner."
+                    else
+                        msg = "ACF damage is currently blocked due to recent use of the contraption scanner. Please try again in " .. math.Round(scanner_damageCooldown - (now - started), 2) .. " seconds."
+                    end
+
+                    ACF.SendNotify(owner, false, msg)
                 end
                 scanner_acfDamage_notifiedThisTick[owner] = true
                 return false

--- a/lua/acf/scanner/scanner_sh.lua
+++ b/lua/acf/scanner/scanner_sh.lua
@@ -15,7 +15,6 @@ local net_ReadBool = net.ReadBool
 local net_ReadEntity = net.ReadEntity
 local net_ReadString = net.ReadString
 local net_ReadUInt = net.ReadUInt
-local net_ReadFloat = net.ReadFloat
 local net_ReadVector = net.ReadVector
 local net_Send = net.Send
 local net_Broadcast = net.Broadcast
@@ -25,7 +24,6 @@ local net_WriteBool = net.WriteBool
 local net_WriteEntity = net.WriteEntity
 local net_WriteString = net.WriteString
 local net_WriteUInt = net.WriteUInt
-local net_WriteFloat = net.WriteFloat
 local net_WriteVector = net.WriteVector
 
 -- Color helpers
@@ -239,12 +237,7 @@ if SERVER then
 
             if started == true or (now - started < scanner_damageCooldown) then
                 if not doNotNotify then
-                    NetStart("DamageBlocked")
-                    net_WriteBool(started == true)
-                    if started ~= true then
-                        net_WriteFloat(scanner_damageCooldown - (now - started))
-                    end
-                    net.Send(owner)
+                    ACF.SendNotify(owner, false, started == true and "ACF damage is currently blocked due to current use of the contraption scanner." or "ACF damage is currently blocked due to recent use of the contraption scanner. Please try again in " .. math.Round(scanner_damageCooldown - (now - started), 2) .. " seconds.")
                 end
                 scanner_acfDamage_notifiedThisTick[owner] = true
                 return false
@@ -973,17 +966,6 @@ if CLIENT then
         end
         return isValid
     end
-
-    NetReceive("DamageBlocked", function()
-        local started, timeLeft = net_ReadBool(), not started and net_ReadFloat()
-
-        if started then
-            notification.AddLegacy("ACF damage is currently blocked due to current use of the contraption scanner.", NOTIFY_ERROR, 5)
-        else
-            notification.AddLegacy("ACF damage is currently blocked due to recent use of the contraption scanner. Please try again in " .. math.Round(timeLeft, 2) .. " seconds.", NOTIFY_ERROR, 7)
-        end
-        surface.PlaySound("buttons/button10.wav")
-    end)
 
     local ent2bp = {}
 


### PR DESCRIPTION
In-scanner: damage is completely blocked
Upon exiting scanner: damage cooldown starts, 60 seconds of no scanner use before damage works again for you

![image](https://github.com/ACF-Team/ACF-3/assets/106459595/a4c8e1c5-4878-449b-abc9-558e34006b12)