### PR TITLE
Use ACF_PersistedData_Loaded hook

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -153,7 +153,7 @@ end
 if SERVER then
 	util.AddNetworkString("ACF_UpdateEntity")
 
-	hook.Add("PlayerConnect", "ACF Workshop Content", function()
+	hook.Add("ACF_PersistedData_Loaded", "ACF Workshop Content", function()
 		if ACF.WorkshopContent then
 			resource.AddWorkshop("2183798463") -- Playermodel Seats
 			resource.AddWorkshop("3248769144") -- ACF-3 Base
@@ -164,8 +164,6 @@ if SERVER then
 			resource.AddWorkshop("2099387099") -- ACF-3 Removed Sounds
 			resource.AddWorkshop("2782407502") -- ACF-3 Removed Models
 		end
-
-		hook.Remove("PlayerConnect", "ACF Workshop Content")
 	end)
 elseif CLIENT then
 	CreateClientConVar("acf_show_entity_info", 1, true, false, "Defines under what conditions the info bubble on ACF entities will be shown. 0 = Never, 1 = When not seated, 2 = Always", 0, 2)

--- a/lua/acf/core/networking/data_vars/data_vars_sh.lua
+++ b/lua/acf/core/networking/data_vars/data_vars_sh.lua
@@ -139,6 +139,7 @@ do -- Data persisting
 			SetFunction(Key, Default)
 		end
 
+		hook.Run("ACF_PersistedData_Loaded")
 		hook.Remove("Initialize", "ACF Load Persisted Data")
 	end)
 end


### PR DESCRIPTION
Fixes load order issues that would prevent workshop files from being loaded by adding a `ACF_PersistedData_Loaded` hook and using it for acf workshop content loading.