### PR TITLE
Fix nil error

### DIFF
--- a/lua/acf/core/networking/networking_sv.lua
+++ b/lua/acf/core/networking/networking_sv.lua
@@ -91,7 +91,10 @@ net.Receive("ACF_Networking", function(_, Player)
 	local Bytes   = net.ReadUInt(12)
 	-- This decompression limit should only be as high as it absolutely needs to be
 	local String  = Decompress(net.ReadData(Bytes), 256)
+	if not String then return end
+
 	local Message = ToTable(String)
+	if not Message then return end
 
 	for Name, Data in pairs(Message) do
 		local Handler = Receiver[Name]


### PR DESCRIPTION
I didn't go into the error in depth, but we should never trust the client anyway. Fixes:
```
[[ACF] Armored Combat Framework] lua/acf/core/networking/networking_sv.lua:94: bad argument #1 to 'ToTable' (string expected, got nil)
1. ToTable - [C]:-1
 2. func - lua/acf/core/networking/networking_sv.lua:94
  3. unknown - lua/includes/extensions/net.lua:38
```