### PR TITLE
Fix client lua error/reduce network usage a bit

### DIFF
--- a/lua/acf/core/networking/networking_cl.lua
+++ b/lua/acf/core/networking/networking_cl.lua
@@ -52,9 +52,9 @@ function Network.Send(Name, ...)
 end
 
 net.Receive("ACF_Networking", function(Bits)
-	local String  = Decompress(net.ReadData(Bytes * 8))
+	local String  = Decompress(net.ReadData(Bits * 8))
 	if not String then return end
-	
+
 	local Message = ToTable(String)
 
 	if not Message then
@@ -62,7 +62,7 @@ net.Receive("ACF_Networking", function(Bits)
 		local Total = Bits * 0.125 -- Bits to bytes
 		local JSON  = String ~= "" and String or "Empty, possible overflow."
 
-		ErrorNoHalt(Error:format(Bytes, Total, JSON))
+		ErrorNoHalt(Error:format(Bits * 8, Total, JSON))
 
 		return
 	end

--- a/lua/acf/core/networking/networking_cl.lua
+++ b/lua/acf/core/networking/networking_cl.lua
@@ -52,8 +52,9 @@ function Network.Send(Name, ...)
 end
 
 net.Receive("ACF_Networking", function(Bits)
-	local Bytes   = net.ReadUInt(12)
-	local String  = Decompress(net.ReadData(Bytes))
+	local String  = Decompress(net.ReadData(Bytes * 8))
+	if not String then return end
+	
 	local Message = ToTable(String)
 
 	if not Message then

--- a/lua/acf/core/networking/networking_sv.lua
+++ b/lua/acf/core/networking/networking_sv.lua
@@ -28,11 +28,8 @@ local function SendMessages()
 	local All = Messages.All
 
 	if All and next(All) then
-		local Compressed = Compress(ToJSON(All))
-
 		net.Start("ACF_Networking")
-			net.WriteUInt(#Compressed, 12)
-			net.WriteData(Compressed)
+			net.WriteData(Compress(ToJSON(All)))
 		net.Broadcast()
 
 		Messages.All = nil
@@ -40,11 +37,8 @@ local function SendMessages()
 
 	if next(Messages) then
 		for Target, Data in pairs(Messages) do
-			local Compressed = Compress(ToJSON(Data))
-
 			net.Start("ACF_Networking")
-				net.WriteUInt(#Compressed, 12)
-				net.WriteData(Compressed)
+				net.WriteData(Compress(ToJSON(Data)))
 			net.Send(Target)
 
 			Messages[Target] = nil


### PR DESCRIPTION
Fixes:
```
[[ACF-3] Armored Combat Framework] lua/acf/core/networking/networking_cl.lua:57: bad argument #1 to 'ToTable' (string expected, got nil)
1. ToTable - [C]:-1
 2. func - lua/acf/core/networking/networking_cl.lua:57
  3. unknown - lua/includes/extensions/net.lua:38
```
We can avoid writing UInt on the server side as we can use the message length instead. I didn't do it on the client as I don't know if it can cause problems with spam messages.