### PR TITLE
Update acfarmorprop.lua to fix primitives

### DIFF
--- a/lua/weapons/gmod_tool/stools/acfarmorprop.lua
+++ b/lua/weapons/gmod_tool/stools/acfarmorprop.lua
@@ -353,7 +353,7 @@ else -- Serverside-only stuff
 		local ArmorMod  = EntMods and EntMods.ACF_Armor
 
 		UpdateArmor(_, Entity, ArmorMod)
-		Properties.mass = nil -- Don't let the primitive reset its own mass
+		Properties.mass = Entity.ACF.Mass -- Don't let the primitive reset its own mass, use ACF mass instead
 	end)
 
 	duplicator.RegisterEntityModifier("acfsettings", function(_, Entity, Data)


### PR DESCRIPTION
Setting Properties.mass to nil resulted in some issues with primitives being set to 1kg when pasted in large amounts. Using Entity.ACF.Mass instead prevents this problem entirely