### PR TITLE
Try to fix x86-64 crash

### DIFF
--- a/lua/acf/damage/debris_cl.lua
+++ b/lua/acf/damage/debris_cl.lua
@@ -57,6 +57,7 @@ local function Ignite(Entity, Lifetime, IsGib)
 end
 
 local function CreateDebris(Model, Position, Angles, Material, Color, Normal, Power, ShouldIgnite)
+    if not util.IsValidModel(Model) then return end
     local Debris = ents.CreateClientProp(Model)
 
     if not IsValid(Debris) then return end

--- a/lua/acf/damage/debris_cl.lua
+++ b/lua/acf/damage/debris_cl.lua
@@ -57,7 +57,9 @@ local function Ignite(Entity, Lifetime, IsGib)
 end
 
 local function CreateDebris(Model, Position, Angles, Material, Color, Normal, Power, ShouldIgnite)
+    -- TODO: This fixes a crashing bug, but the underlying issue that Model can sometimes be blank ("") isn't fixed yet
     if not util.IsValidModel(Model) then return end
+    
     local Debris = ents.CreateClientProp(Model)
 
     if not IsValid(Debris) then return end

--- a/lua/acf/damage/debris_cl.lua
+++ b/lua/acf/damage/debris_cl.lua
@@ -59,7 +59,7 @@ end
 local function CreateDebris(Model, Position, Angles, Material, Color, Normal, Power, ShouldIgnite)
     -- TODO: This fixes a crashing bug, but the underlying issue that Model can sometimes be blank ("") isn't fixed yet
     if not util.IsValidModel(Model) then return end
-    
+
     local Debris = ents.CreateClientProp(Model)
 
     if not IsValid(Debris) then return end


### PR DESCRIPTION
@brandonsturgeon received this stack traceback from a hard crash:

-Lua Stack Traces-
==================
  Client
    0. CreateClientProp - [C]:-1
      1. CreateDebris - addons/acf-3/lua/acf/damage/debris_cl.lua:60
        2. CreateDebris - addons/acf-3/lua/acf/damage/debris_cl.lua:138
          3. (null) - addons/acf-3/lua/acf/damage/debris_cl.lua:174

  Server
    Lua Interface = NULL

  MenuSystem
*Not in Lua call OR Lua has panicked*

Seems to happen when CreateClientProp's model argument is blank (""). This likely is why x86-64 was crashing so much for the last few months. Seems like an easy enough fix?