### PR TITLE
Update init.lua to solve weight inaccuracy

### DIFF
--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -114,14 +114,13 @@ do -- Spawn and Update functions --------------------------------
 		return Result
 	end
 
-	local function GetMass(Model, PhysObj, Class, Weapon)
-		if Weapon then return Weapon.Mass end
-
-		local Volume = PhysObj:GetVolume()
-		local Factor = Volume / ModelData.GetModelVolume(Model)
-
-		return math.Round(Class.Mass * Factor)
-	end
+	local function GetMass(Caliber, Class, Weapon)
+	        if Weapon then return Weapon.Mass end
+		
+	        local Factor = Caliber / Class.Caliber.Base
+		
+		return math.Round(Class.Mass * Factor ^ 3) -- 3d space so scaling has a cubing effect
+    	end
 
 	local function UpdateWeapon(Entity, Data, Class, Weapon)
 		local Model   = Weapon and Weapon.Model or Class.Model
@@ -190,7 +189,7 @@ do -- Spawn and Update functions --------------------------------
 		local PhysObj = Entity.ACF.PhysObj
 
 		if IsValid(PhysObj) then
-			local Mass = GetMass(Model, PhysObj, Class, Weapon)
+			local Mass = GetMass(Caliber, Class, Weapon)
 
 			Contraption.SetMass(Entity, Mass)
 		end


### PR DESCRIPTION
Resolves an issue introduced with [gun scaling corrections](https://github.com/ACF-Team/ACF-3/commit/e5fa45de648ca66bbd9fcee926dba78e48f8157f) where guns, if they had a corrective scale factor, did not weigh what they should