### PR TITLE
use nil instead _

### DIFF
--- a/lua/acf/damage/damage_sv.lua
+++ b/lua/acf/damage/damage_sv.lua
@@ -220,7 +220,7 @@ function Damage.doPropDamage(Entity, DmgResult)
 		EntACF.Health = NewHealth
 		EntACF.Armour = EntACF.MaxArmour * (0.5 + NewHealth / MaxHealth * 0.5) -- Simulating the plate weakening after a hit
 
-		Damage.Network(Entity, _, NewHealth, MaxHealth)
+		Damage.Network(Entity, nil, NewHealth, MaxHealth)
 	end
 
 	return HitRes


### PR DESCRIPTION
One of the addons uses _ as a global variable (it's a pity that such addons exist), it stores a number that creates errors. [acf-3] addons/acf-3/lua/acf/damage/damage_sv.lua:19: bad argument #1 to 'Send' (Entity expected, got number)
  1. Send - [C]:-1
   2. unknown - addons/acf-3/lua/acf/damage/damage_sv.lua:19