### PR TITLE
Change driveshaft excessive angle check

### DIFF
--- a/lua/acf/core/utilities/util_sh.lua
+++ b/lua/acf/core/utilities/util_sh.lua
@@ -334,12 +334,15 @@ do
 		-- For the entity receiving power, the deviation between the shaft and what it considers "straight"
 		local InToOut = math.deg(math.acos((IP - OP):GetNormalized():Dot(OutputWorldDir)))
 
-		-- The sum of the deviations
-		return OutToIn + InToOut
+		-- Table of deviations
+		return {OutToIn,InToOut}
 	end
 
 	function ACF.IsDriveshaftAngleExcessive(InputEntity, Input, OutputEntity, Output)
-		return ACF.DetermineDriveshaftAngle(InputEntity, Input, OutputEntity, Output) > ACF.MaxDriveshaftAngle
+		local Deviations = ACF.DetermineDriveshaftAngle(InputEntity, Input, OutputEntity, Output)
+
+		--Check if either direction has an excessive angle.
+		return Deviations[1] > ACF.MaxDriveshaftAngle or Deviations[2] > ACF.MaxDriveshaftAngle
 	end
 end
 


### PR DESCRIPTION
Not sure what the reasoning was behind the original implementation, but this makes more sense given how ACF.MaxDriveshaftAngle is defined.

This changes the behavior to check if either direction exceeds ACF.MaxDriveshaftAngle, from check if sum of direction deviations is greater than ACF.MaxDriveshaftAngle.