### PR TITLE
Edit to allow missiles with AP warheads to function

### DIFF
--- a/lua/acf/entities/ammo_types/ap.lua
+++ b/lua/acf/entities/ammo_types/ap.lua
@@ -132,7 +132,7 @@ if SERVER then
 		local Target = Trace.Entity
 		local Filter = Bullet.Filter
 
-		if ACF.Check(Target) then
+		if ACF.Check(Target) and Bullet.Gun ~= Trace.Entity then
 			local Speed  = Bullet.Flight:Length() / ACF.Scale
 			local Energy = ACF.Kinetic(Speed, Bullet.ProjMass)
 


### PR DESCRIPTION
This is for the LOSAT on ACF Missiles to function correctly. I've tested and found that this doesn't effect anything negatively. Without this, missiles with AP warheads like to try to penetrate themselves whenever they hit something.