### PR TITLE
Radar/missile changes

### DIFF
--- a/lua/acf/entities/missiles/asm.lua
+++ b/lua/acf/entities/missiles/asm.lua
@@ -192,8 +192,8 @@ Missiles.RegisterItem("Ataka ASM", "ATGM", {
 		Armor           = 1,
 		ProjLength      = 17.5,
 		PropLength      = 68,
-		Thrust          = 230000, -- in kg*in/s^2
-		FuelConsumption = 0.03, -- in g/s/f
+		Thrust          = 210000, -- in kg*in/s^2
+		FuelConsumption = 0.032, -- in g/s/f
 		StarterPercent  = 0.2,
 		MaxAgilitySpeed = 200, -- in m/s
 		DragCoef        = 0.024,

--- a/lua/acf/entities/missiles/uar.lua
+++ b/lua/acf/entities/missiles/uar.lua
@@ -132,7 +132,7 @@ Missiles.RegisterItem("SPG-9 ASR", "UAR", {
 	Navigation  = "Chase",
 	Fuzes		= { Contact = true },
 	Agility     = 1,
-	ArmDelay	= 0, -- :)
+	ArmDelay	= 0.1,
 	HitDeviate	= false,
 	Round = {
 		Model           = "models/missiles/rs82.mdl",
@@ -141,11 +141,11 @@ Missiles.RegisterItem("SPG-9 ASR", "UAR", {
 		Armor           = 1,
 		ProjLength      = 20.07,
 		PropLength      = 67.8,
-		Thrust          = 180000, -- in kg*in/s^2
-		FuelConsumption = 0.03, -- in g/s/f
-		StarterPercent  = 0.4,
+		Thrust          = 115000, -- in kg*in/s^2
+		FuelConsumption = 0.042, -- in g/s/f
+		StarterPercent  = 0.3,
 		MaxAgilitySpeed = 1, -- in m/s
-		DragCoef        = 0.002,
+		DragCoef        = 0.008,
 		FinMul          = 0,
 		GLimit          = 1,
 		TailFinMul      = 0.06,

--- a/lua/acf/entities/sensors/radars/helpers_sv.lua
+++ b/lua/acf/entities/sensors/radars/helpers_sv.lua
@@ -9,8 +9,9 @@ local Trace = ACF.trace
 -- Minimum target size (in inches) detectable at a given distance, given the radar's own MinSizeAtRange
 -- (the smallest target it can see at its own max range) and Range. Scales down toward 0 as distance
 -- approaches 0, so all radars can see small targets up close, but only larger radars can see
--- small targets far away. Non linear to mimic how realistic detection strength falls off with range
-local MinSizeExponent = 1.5
+-- small targets far away. Non linear to mimic how realistic detection strength falls off with range.
+-- Higher exponent = detection of small targets falls off faster with range (near targets barely change)
+local MinSizeExponent = 2
 
 function RadarHelpers.GetMinDetectableSize(Radar, EntDist)
 	local MinSizeAtRange = Radar.MinSizeAtRange

--- a/lua/acf/entities/sensors/radars/radar.lua
+++ b/lua/acf/entities/sensors/radars/radar.lua
@@ -44,7 +44,7 @@ do -- Directional radars
 		Mass		= 35,
 		ViewCone	= 60,
 		Range		= 23622, -- ~600m
-		MinSizeAtRange = 10,
+		MinSizeAtRange = 24,
 		Origin		= "radar",
 		SwitchDelay	= 2,
 		ThinkTicks	= 3,
@@ -61,7 +61,7 @@ do -- Directional radars
 		Mass		= 120,
 		ViewCone	= 60,
 		Range		= 31496, -- ~800m
-		MinSizeAtRange = 5,
+		MinSizeAtRange = 14,
 		Origin		= "radar",
 		SwitchDelay	= 4,
 		ThinkTicks	= 3,
@@ -78,7 +78,7 @@ do -- Directional radars
 		Mass		= 220,
 		ViewCone	= 60,
 		Range		= 39370, -- ~1000m
-		MinSizeAtRange = 2,
+		MinSizeAtRange = 7,
 		Origin		= "radar",
 		SwitchDelay	= 8,
 		ThinkTicks	= 3,
@@ -120,7 +120,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_sml.mdl",
 		Mass		= 80,
 		Range		= 18898, -- ~480m
-		MinSizeAtRange = 10,
+		MinSizeAtRange = 24,
 		Origin		= "radar",
 		SwitchDelay	= 3,
 		ThinkTicks	= 10,
@@ -136,7 +136,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_mid.mdl",
 		Mass		= 210,
 		Range		= 25197, -- ~640m
-		MinSizeAtRange = 5,
+		MinSizeAtRange = 14,
 		Origin		= "radar",
 		SwitchDelay	= 6,
 		ThinkTicks	= 10,
@@ -152,7 +152,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_big.mdl",
 		Mass		= 540,
 		Range		= 31496, -- ~800m
-		MinSizeAtRange = 2,
+		MinSizeAtRange = 7,
 		Origin		= "radar",
 		SwitchDelay	= 12,
 		ThinkTicks	= 10,

--- a/lua/acf/entities/sensors/radars/radar.lua
+++ b/lua/acf/entities/sensors/radars/radar.lua
@@ -44,7 +44,7 @@ do -- Directional radars
 		Mass		= 35,
 		ViewCone	= 60,
 		Range		= 23622, -- ~600m
-		MinSizeAtRange = 24,
+		MinSizeAtRange = 36, -- gives 4in at 200m
 		Origin		= "radar",
 		SwitchDelay	= 2,
 		ThinkTicks	= 3,
@@ -61,7 +61,7 @@ do -- Directional radars
 		Mass		= 120,
 		ViewCone	= 60,
 		Range		= 31496, -- ~800m
-		MinSizeAtRange = 14,
+		MinSizeAtRange = 21,
 		Origin		= "radar",
 		SwitchDelay	= 4,
 		ThinkTicks	= 3,
@@ -78,7 +78,7 @@ do -- Directional radars
 		Mass		= 220,
 		ViewCone	= 60,
 		Range		= 39370, -- ~1000m
-		MinSizeAtRange = 7,
+		MinSizeAtRange = 10.5,
 		Origin		= "radar",
 		SwitchDelay	= 8,
 		ThinkTicks	= 3,
@@ -120,7 +120,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_sml.mdl",
 		Mass		= 80,
 		Range		= 18898, -- ~480m
-		MinSizeAtRange = 24,
+		MinSizeAtRange = 36,
 		Origin		= "radar",
 		SwitchDelay	= 3,
 		ThinkTicks	= 10,
@@ -136,7 +136,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_mid.mdl",
 		Mass		= 210,
 		Range		= 25197, -- ~640m
-		MinSizeAtRange = 14,
+		MinSizeAtRange = 21,
 		Origin		= "radar",
 		SwitchDelay	= 6,
 		ThinkTicks	= 10,
@@ -152,7 +152,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_big.mdl",
 		Mass		= 540,
 		Range		= 31496, -- ~800m
-		MinSizeAtRange = 7,
+		MinSizeAtRange = 10.5,
 		Origin		= "radar",
 		SwitchDelay	= 12,
 		ThinkTicks	= 10,

--- a/lua/acf/entities/sensors/radars/radar.lua
+++ b/lua/acf/entities/sensors/radars/radar.lua
@@ -44,7 +44,7 @@ do -- Directional radars
 		Mass		= 35,
 		ViewCone	= 60,
 		Range		= 23622, -- ~600m
-		MinSizeAtRange = 36, -- gives 4in at 200m
+		MinSizeAtRange = 24,
 		Origin		= "radar",
 		SwitchDelay	= 2,
 		ThinkTicks	= 3,
@@ -61,7 +61,7 @@ do -- Directional radars
 		Mass		= 120,
 		ViewCone	= 60,
 		Range		= 31496, -- ~800m
-		MinSizeAtRange = 21,
+		MinSizeAtRange = 14,
 		Origin		= "radar",
 		SwitchDelay	= 4,
 		ThinkTicks	= 3,
@@ -78,7 +78,7 @@ do -- Directional radars
 		Mass		= 220,
 		ViewCone	= 60,
 		Range		= 39370, -- ~1000m
-		MinSizeAtRange = 10.5,
+		MinSizeAtRange = 7,
 		Origin		= "radar",
 		SwitchDelay	= 8,
 		ThinkTicks	= 3,
@@ -120,7 +120,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_sml.mdl",
 		Mass		= 80,
 		Range		= 18898, -- ~480m
-		MinSizeAtRange = 36,
+		MinSizeAtRange = 24,
 		Origin		= "radar",
 		SwitchDelay	= 3,
 		ThinkTicks	= 10,
@@ -136,7 +136,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_mid.mdl",
 		Mass		= 210,
 		Range		= 25197, -- ~640m
-		MinSizeAtRange = 21,
+		MinSizeAtRange = 14,
 		Origin		= "radar",
 		SwitchDelay	= 6,
 		ThinkTicks	= 10,
@@ -152,7 +152,7 @@ do -- Spherical radars
 		Model		= "models/radar/radar_sp_big.mdl",
 		Mass		= 540,
 		Range		= 31496, -- ~800m
-		MinSizeAtRange = 10.5,
+		MinSizeAtRange = 7,
 		Origin		= "radar",
 		SwitchDelay	= 12,
 		ThinkTicks	= 10,

--- a/lua/acf/entities/sensors/sensors_menu_cl.lua
+++ b/lua/acf/entities/sensors/sensors_menu_cl.lua
@@ -3,11 +3,11 @@ local ACF  = ACF
 do	-- Radars
 	local Text = "View Cone : %s degrees\nView Range : %s\nMin. Target Size (at max range) : %s\nMass : %s kg\n"
 	local SizeColor = Color(255, 0, 0)
-	local FormulaText = "The minimum target size a radar can detect shrinks the closer a target gets. Smaller radars can only see small targets up close, while larger radars can see small targets much further out. A target smaller than the curve at its current distance won't be detected.\n\nMinimum detectable size = Min. Target Size x (Distance / View Range) ^ 1.5"
+	local FormulaText = "The minimum target size a radar can detect shrinks the closer a target gets. Smaller radars can only see small targets up close, while larger radars can see small targets much further out. A target smaller than the curve at its current distance won't be detected.\n\nMinimum detectable size = Min. Target Size x (Distance / View Range) ^ 2"
 	local DetectTypesText = "Radars can be set to detect Contraptions, Missiles, or both. Radars that can only detect one target type receive a slight cost discount."
 
-	-- Mirrors GetMinDetectableSize in lua/entities/acf_radar/init.lua; a target smaller than this, at this distance, won't be seen by the radar.
-	local MinSizeExponent = 1.5
+	-- Mirrors GetMinDetectableSize in lua/acf/entities/sensors/radars/helpers_sv.lua; a target smaller than this, at this distance, won't be seen by the radar.
+	local MinSizeExponent = 2
 	local function MinDetectableSize(MinSizeAtRange, Range, Dist)
 		if not MinSizeAtRange or not Range or Range <= 0 then return 0 end
 


### PR DESCRIPTION
The recent radar rework which allowed radars to detect both contraptions and missiles significantly altered radar view cones and detection distances. To push radar detection capabilities in a more realistic direction, a system was added to control the detection capability of radars by introducing a minimum target size which scales with distance. The default values for minimum detection sizes in that rework are not sufficient, as very small targets can be detected at unreasonable distances. This PR significantly decreases detection distance of missile-sized targets (especially for smaller radars) and decreases the speeds of Atakas and SPG-9; those two missiles being distinct outliers of their classes to an unreasonable extent.