### PR TITLE
Missile cost / damage fix

### DIFF
--- a/lua/acf/contraption/objects_sv/cost.lua
+++ b/lua/acf/contraption/objects_sv/cost.lua
@@ -106,6 +106,26 @@ do
 			Breakdown["**" .. string.upper(identifier)] = C
 		end
 
+		-- Missiles opt out of CFW contraptions, so the walk above misses them; racks are members and
+		-- know what they carry. Counted skips any the walk did reach (entity-list callers don't filter).
+		local Counted     = Ctrp.entsbyclass.acf_missile
+		local MissileCost = 0
+
+		for Rack in pairs(Ctrp.entsbyclass.acf_rack or {}) do
+			if not IsValid(Rack) then continue end
+
+			for _, Missile in pairs(Rack.Missiles or {}) do
+				if IsValid(Missile) and Missile.GetCost and not (Counted and Counted[Missile]) then
+					MissileCost = MissileCost + Missile:GetCost()
+				end
+			end
+		end
+
+		if MissileCost > 0 then
+			Cost = Cost + MissileCost
+			Breakdown.acf_missile = (Breakdown.acf_missile or 0) + MissileCost
+		end
+
 		self.Cost		= Cost
 		self.Breakdown	= Breakdown
 

--- a/lua/acf/core/networking/model_data/volumetrics_sh.lua
+++ b/lua/acf/core/networking/model_data/volumetrics_sh.lua
@@ -58,6 +58,7 @@ local ArmorableClasses = {
     prop_physics = true,
     starfall_prop = true,
     acf_missile = true,
+    acf_glatgm = true,
 
     -- Vehicles
     prop_vehicle_prisoner_pod = true,

--- a/lua/entities/acf_ammo/modules/cost.lua
+++ b/lua/entities/acf_ammo/modules/cost.lua
@@ -1,15 +1,12 @@
 
 --	Used for figuring costs for gamemode related activities
-function ENT:GetCost()
-	local selftbl	= self:GetTable()
 
-	--PrintTable(selftbl.BulletData)
-
-	--print(selftbl.Capacity, selftbl.BulletData.Type)
+--- Cost of one round. Per-round so a big crate can't dilute the seeker's cost away.
+function ENT:GetRoundCost()
+	local selftbl = self:GetTable()
+	local Cost    = selftbl.RoundData:GetCost(selftbl.BulletData)
 
 	if selftbl.IsMissileAmmo then
-		local Cost	= selftbl.Capacity * selftbl.RoundData:GetCost(selftbl.BulletData)
-
 		if selftbl.GuidanceData then
 			Cost = Cost + selftbl.GuidanceData:GetCost()
 		end
@@ -17,9 +14,11 @@ function ENT:GetCost()
 		if selftbl.FuzeData then
 			Cost = Cost + selftbl.FuzeData:GetCost()
 		end
-
-		return Cost
-	else
-		return selftbl.Capacity * selftbl.RoundData:GetCost(selftbl.BulletData)
 	end
+
+	return Cost
+end
+
+function ENT:GetCost()
+	return self.Capacity * self:GetRoundCost()
 end

--- a/lua/entities/acf_glatgm/init.lua
+++ b/lua/entities/acf_glatgm/init.lua
@@ -81,7 +81,7 @@ function ACF.MakeGLATGM(Player, Gun, BulletData)
 	Entity.Caliber      = Caliber
 	Entity.Weapon       = Gun
 	Entity.BulletData   = table.Copy(BulletData)
-	Entity.ForcedArmor  = 5 -- All missiles should get 5mm
+	Entity.ForcedArmor  = 1 -- Flat 1mm, matching the thinnest missile airframes
 	Entity.ForcedMass   = BulletData.CartMass
 	Entity.UseGuidance  = true
 	Entity.ViewCone     = math.cos(math.rad(50)) -- Number inside is on degrees
@@ -144,12 +144,12 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 		local Ratio = self.ACF.Health / self.ACF.MaxHealth
 		local BulletData = self.BulletData
 
-		-- We give it a chance to explode when it gets penetrated aswell.
-		if math.random() > 0.55 * Ratio then
+		-- Destroyed once penetrated, matching acf_missile
+		if DmgResult.Penetration > self.ForcedArmor then
 			if BulletData.Type == "GLATGM" then
-			BulletData.Type = "HE"
+				BulletData.Type = "HE"
 
-			self:SetNW2String("AmmoType", "HE")
+				self:SetNW2String("AmmoType", "HE")
 			end
 			DetonateMissile(self, Owner)
 

--- a/lua/entities/acf_glatgm/shared.lua
+++ b/lua/entities/acf_glatgm/shared.lua
@@ -4,3 +4,5 @@ ENT.DoNotDuplicate    = true
 ENT.DisableDuplicator = true
 ENT.DoNotTrack        = true
 ENT.IsACFMissile         = true
+ENT.ConvexMaterial = "Aluminum" -- base_wire_entity inherits none; mesh would fall back to "Default"
+ENT.ACF_PreventArmoring = true -- Stops the mesh mass overwriting ForcedMass

--- a/lua/entities/acf_missile/init.lua
+++ b/lua/entities/acf_missile/init.lua
@@ -497,6 +497,26 @@ function ENT:CreateBulletData(Crate)
 	Ammo:Network(self, self.BulletData)
 end
 
+--- Worth one round from its source crate, charged here so ground reloads aren't free.
+function ENT:GetCost()
+	local selftbl = self:GetTable()
+	local Ammo    = selftbl.RoundData
+
+	if not Ammo then return 0 end -- BulletData isn't built yet
+
+	local Cost = Ammo:GetCost(selftbl.BulletData)
+
+	if selftbl.GuidanceData then
+		Cost = Cost + selftbl.GuidanceData:GetCost()
+	end
+
+	if selftbl.FuzeData then
+		Cost = Cost + selftbl.FuzeData:GetCost()
+	end
+
+	return Cost
+end
+
 function ENT:UpdateModel(Model)
 	self:SetModel(Model)
 

--- a/lua/entities/acf_missile/shared.lua
+++ b/lua/entities/acf_missile/shared.lua
@@ -5,3 +5,5 @@ ENT.DoNotDuplicate    = true
 ENT.DisableDuplicator = true
 ENT.DoNotTrack        = true
 ENT.IsACFMissile         = true
+ENT.ConvexMaterial = "Aluminum" -- base_wire_entity inherits none; mesh would fall back to "Default"
+ENT.ACF_PreventArmoring = true -- Stops the mesh mass overwriting ForcedMass


### PR DESCRIPTION
- Missiles loaded on racks now carry their cost over from their ammo crate

- Missile ammo crates now properly account for the cost of each missile; previously, guidance types were a flat value added to the cost of the crate, not per missile

- GLATGM damage path now follows same convention as regular missiles

- Both regular missiles and GLATGM now have Aluminum material forced instead of Default, they still use internal ForcedArmor value for damage though