### PR TITLE
Reup prev PR + Cost rebalance

### DIFF
--- a/lua/acf/core/missiles_globals.lua
+++ b/lua/acf/core/missiles_globals.lua
@@ -10,6 +10,11 @@ ACF.FlareDistractMultiplier = 1 / 35
 ACF.MaxDamageInaccuracy     = 1000
 ACF.DefaultRadarSound       = "buttons/button16.wav"
 
+-- Discount applied when a radar can only detect one target type instead of both
+ACF.RadarSingleTypeDiscount = 5
+ACF.RadarSyncCost           = 1
+ACF.GroundLoaderCost        = 15
+
 game.AddParticles("particles/flares_fx.pcf")
 PrecacheParticleSystem("ACFM_Flare")
 

--- a/lua/acf/core/utilities/util_cl.lua
+++ b/lua/acf/core/utilities/util_cl.lua
@@ -723,7 +723,7 @@ do -- Default turret menus
 				local MaxMass = TurretClass.GetMaxMass(Data, N)
 				local TurretMassText = language.GetPhrase("acf.menu.turrets.turret_mass_text")
 				MassLbl:SetText(TurretMassText:format(TurretClass.GetMass(Data, N), MaxMass))
-				CostLbl:SetText(CostText:format(ACF.GetProperCost((Data.ID == "Turret-H" and 0.1 or 0.2) * N)))
+				CostLbl:SetText(CostText:format(ACF.FormatCost((Data.ID == "Turret-H" and 0.1 or 0.2) * N)))
 
 				TurretData.Teeth		= Teeth
 				TurretData.RingSize		= N
@@ -921,7 +921,7 @@ do -- Default turret menus
 
 				local SizePerc = N ^ 2
 				MassLbl:SetText(MassText:format(math.Round(math.max(Data.Mass * SizePerc, 5), 1)))
-				CostLbl:SetText(CostText:format(ACF.GetProperCost(N * 2)))
+				CostLbl:SetText(CostText:format(ACF.FormatCost(N * 2)))
 
 				TurretData.Torque	= MotorClass.GetTorque(Data, N)
 				TorqLbl:SetText(TorqText:format(TurretData.Torque))
@@ -1011,7 +1011,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
-			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.GetProperCost(Data.IsDual and 8 or 4)))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.FormatCost(Data.IsDual and 8 or 4)))
 
 			if Data.IsDual then
 				Menu:AddLabel("#acf.menu.gyros.dual_desc")
@@ -1032,7 +1032,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
-			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.GetProperCost(Data.IsRemote and 100 or 5)))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.FormatCost(Data.IsRemote and 100 or 5)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(1, true)
@@ -1049,7 +1049,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
-			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.GetProperCost(5)))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.FormatCost(5)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(1, true)

--- a/lua/acf/core/utilities/util_cl.lua
+++ b/lua/acf/core/utilities/util_cl.lua
@@ -1032,7 +1032,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
-			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.FormatCost(Data.IsRemote and 100 or 5)))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.FormatCost(Data.IsRemote and 70 or 5)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(1, true)

--- a/lua/acf/core/utilities/util_cl.lua
+++ b/lua/acf/core/utilities/util_cl.lua
@@ -561,6 +561,8 @@ do -- Default turret menus
 			local MassText		= language.GetPhrase("acf.menu.turrets.mass_text")
 			local RingStats		= Menu:AddLabel(TurretText:format(0, 0))
 			local MassLbl		= Menu:AddLabel(MassText:format(0, 0))
+			local CostText		= language.GetPhrase("acf.menu.turrets.cost_text")
+			local CostLbl		= Menu:AddLabel(CostText:format(0))
 
 			local ArcSettings	= Menu:AddCollapsible("#acf.menu.turrets.arc_settings", nil, "icon16/chart_pie_edit.png")
 
@@ -721,6 +723,7 @@ do -- Default turret menus
 				local MaxMass = TurretClass.GetMaxMass(Data, N)
 				local TurretMassText = language.GetPhrase("acf.menu.turrets.turret_mass_text")
 				MassLbl:SetText(TurretMassText:format(TurretClass.GetMass(Data, N), MaxMass))
+				CostLbl:SetText(CostText:format(ACF.GetProperCost((Data.ID == "Turret-H" and 0.1 or 0.2) * N)))
 
 				TurretData.Teeth		= Teeth
 				TurretData.RingSize		= N
@@ -812,6 +815,8 @@ do -- Default turret menus
 			local TorqText			= language.GetPhrase("acf.menu.turrets.motors.torque_text")
 			local MassLbl			= Menu:AddLabel(TurretMassText:format(0, 0))
 			local TorqLbl			= Menu:AddLabel(TorqText:format(0))
+			local CostText			= language.GetPhrase("acf.menu.turrets.cost_text")
+			local CostLbl			= Menu:AddLabel(CostText:format(0))
 
 			-- Simulation
 
@@ -916,6 +921,7 @@ do -- Default turret menus
 
 				local SizePerc = N ^ 2
 				MassLbl:SetText(MassText:format(math.Round(math.max(Data.Mass * SizePerc, 5), 1)))
+				CostLbl:SetText(CostText:format(ACF.GetProperCost(N * 2)))
 
 				TurretData.Torque	= MotorClass.GetTorque(Data, N)
 				TorqLbl:SetText(TorqText:format(TurretData.Torque))
@@ -1005,6 +1011,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.GetProperCost(Data.IsDual and 8 or 4)))
 
 			if Data.IsDual then
 				Menu:AddLabel("#acf.menu.gyros.dual_desc")
@@ -1025,6 +1032,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.GetProperCost(Data.IsRemote and 100 or 5)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(1, true)
@@ -1041,6 +1049,7 @@ do -- Default turret menus
 
 			local MassText = language.GetPhrase("acf.menu.turrets.mass_text")
 			Menu:AddLabel(MassText:format(Data.Mass))
+			Menu:AddLabel(language.GetPhrase("acf.menu.turrets.cost_text"):format(ACF.GetProperCost(5)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(1, true)

--- a/lua/acf/core/utilities/util_sh.lua
+++ b/lua/acf/core/utilities/util_sh.lua
@@ -273,6 +273,13 @@ do -- Unit conversion
 
 		return math.Round(Kilograms * Mult, 2) .. " " .. Unit
 	end
+
+	--- Formats a contraption cost the same way the menu and overlays present it.
+	--- @param Points number The cost in points
+	--- @return string Text The formatted cost
+	function ACF.GetProperCost(Points)
+		return math.Round(Points or 0, 2) .. " pts"
+	end
 end
 --[[
 -- Pretty much unused, should be moved into the ACF namespace or just removed

--- a/lua/acf/core/utilities/util_sh.lua
+++ b/lua/acf/core/utilities/util_sh.lua
@@ -262,7 +262,7 @@ do -- Unit conversion
 		end
 	end
 
-	function ACF.GetProperMass(Kilograms)
+	function ACF.FormatMass(Kilograms)
 		local Unit, Mult = "g", 1000
 
 		if Kilograms >= 1000 then
@@ -277,7 +277,7 @@ do -- Unit conversion
 	--- Formats a contraption cost the same way the menu and overlays present it.
 	--- @param Points number The cost in points
 	--- @return string Text The formatted cost
-	function ACF.GetProperCost(Points)
+	function ACF.FormatCost(Points)
 		return math.Round(Points or 0, 2) .. " pts"
 	end
 end

--- a/lua/acf/entities/ammo_types/ap.lua
+++ b/lua/acf/entities/ammo_types/ap.lua
@@ -198,10 +198,16 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return (BulletData.ProjMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant)
+end
+
 if SERVER then
 	local Ballistics = ACF.Ballistics
 	local Entities   = Classes.Entities
-	local Conversion	= ACF.PointConversion
 
 	Entities.AddArguments("acf_ammo", "RoundLength", "PropRatio", "Tracer", "CaseScale") -- Adding extra info to ammo crates
 
@@ -257,10 +263,6 @@ if SERVER then
 		local Data = self:GetDisplayData(BulletData)
 		State:AddNumber("Muzzle Velocity", BulletData.MuzzleVel, " m/s")
 		State:AddNumber("Max Penetration", Data.MaxPen, " mm")
-	end
-
-	function Ammo:GetCost(BulletData)
-		return (BulletData.ProjMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant)
 	end
 
 	function Ammo:PropImpact(Bullet, Trace)

--- a/lua/acf/entities/ammo_types/ap.lua
+++ b/lua/acf/entities/ammo_types/ap.lua
@@ -472,8 +472,8 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_ap")
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass)
 		end)

--- a/lua/acf/entities/ammo_types/apcr.lua
+++ b/lua/acf/entities/ammo_types/apcr.lua
@@ -50,13 +50,16 @@ function Ammo:BaseConvert(ToolData)
 	return Data, GUIData
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return (BulletData.ProjMass * Conversion.Steel * 2.5) + (BulletData.PropMass * Conversion.Propellant)
+end
+
 if SERVER then
-	local Conversion	= ACF.PointConversion
 
 	-- Since APCR
-	function Ammo:GetCost(BulletData)
-		return (BulletData.ProjMass * Conversion.Steel * 2.5) + (BulletData.PropMass * Conversion.Propellant)
-	end
 
 	function Ammo:Network(Entity, BulletData)
 		Ammo.BaseClass.Network(self, Entity, BulletData)

--- a/lua/acf/entities/ammo_types/apds.lua
+++ b/lua/acf/entities/ammo_types/apds.lua
@@ -52,14 +52,16 @@ function Ammo:BaseConvert(ToolData)
 	return Data, GUIData
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	local SabotMass	= BulletData.CartMass - BulletData.PropMass - BulletData.ProjMass
+
+	return (BulletData.ProjMass * Conversion.Steel * 6) + (BulletData.PropMass * Conversion.Propellant) + (SabotMass * Conversion.Aluminum)
+end
+
 if SERVER then
-	local Conversion	= ACF.PointConversion
-
-	function Ammo:GetCost(BulletData)
-		local SabotMass	= BulletData.CartMass - BulletData.PropMass - BulletData.ProjMass
-
-		return (BulletData.ProjMass * Conversion.Steel * 6) + (BulletData.PropMass * Conversion.Propellant) + (SabotMass * Conversion.Aluminum)
-	end
 
 	function Ammo:Network(Entity, BulletData)
 		Ammo.BaseClass.Network(self, Entity, BulletData)

--- a/lua/acf/entities/ammo_types/apds.lua
+++ b/lua/acf/entities/ammo_types/apds.lua
@@ -16,6 +16,7 @@ function Ammo:OnLoaded()
 		AC = true,
 		SA = true,
 		RAC = true,
+		LAC = true,
 	})
 end
 

--- a/lua/acf/entities/ammo_types/apfsds.lua
+++ b/lua/acf/entities/ammo_types/apfsds.lua
@@ -110,8 +110,16 @@ function Ammo:BaseConvert(ToolData)
 	return Data, GUIData
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	local SabotMass	= BulletData.CartMass - BulletData.PropMass - BulletData.ProjMass
+
+	return (BulletData.ProjMass * Conversion.Tungsten) + (BulletData.PropMass * Conversion.Propellant) + (SabotMass * Conversion.Aluminum)
+end
+
 if SERVER then
-	local Conversion	= ACF.PointConversion
 	local Entities		= ACF.Classes.Entities
 
 	Entities.AddArguments("acf_ammo", "TelescopeRatio") -- Adding extra info to ammo crates
@@ -120,12 +128,6 @@ if SERVER then
 		Ammo.BaseClass.OnLast(self, Entity)
 
 		Entity.TelescopeRatio = nil
-	end
-
-	function Ammo:GetCost(BulletData)
-		local SabotMass	= BulletData.CartMass - BulletData.PropMass - BulletData.ProjMass
-
-		return (BulletData.ProjMass * Conversion.Tungsten) + (BulletData.PropMass * Conversion.Propellant) + (SabotMass * Conversion.Aluminum)
 	end
 
 	function Ammo:Network(Entity, BulletData)

--- a/lua/acf/entities/ammo_types/aphe.lua
+++ b/lua/acf/entities/ammo_types/aphe.lua
@@ -115,16 +115,18 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return ((BulletData.ProjMass - BulletData.FillerMass) * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.CompB)
+end
+
 if SERVER then
 	local Entities = Classes.Entities
 	local Objects  = Damage.Objects
-	local Conversion	= ACF.PointConversion
 
 	Entities.AddArguments("acf_ammo", "FillerRatio", "PenFuze", "FuzeDelay") -- Adding extra info to ammo crates
-
-	function Ammo:GetCost(BulletData)
-		return ((BulletData.ProjMass - BulletData.FillerMass) * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.CompB)
-	end
 
 	function Ammo:OnLast(Entity)
 		Ammo.BaseClass.OnLast(self, Entity)

--- a/lua/acf/entities/ammo_types/aphe.lua
+++ b/lua/acf/entities/ammo_types/aphe.lua
@@ -376,9 +376,9 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_he")
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
-			local Filler	= ACF.GetProperMass(BulletData.FillerMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
+			local Filler	= ACF.FormatMass(BulletData.FillerMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass, Filler)
 		end)
@@ -390,7 +390,7 @@ else
 
 			local Text	   = language.GetPhrase("acf.menu.ammo.filler_stats_he")
 			local Blast	   = math.Round(BulletData.BlastRadius, 2)
-			local FragMass = ACF.GetProperMass(BulletData.FragMass)
+			local FragMass = ACF.FormatMass(BulletData.FragMass)
 			local FragVel  = math.Round(BulletData.FragVel, 2)
 
 			return Text:format(Blast, BulletData.Fragments, FragMass, FragVel)

--- a/lua/acf/entities/ammo_types/fl.lua
+++ b/lua/acf/entities/ammo_types/fl.lua
@@ -101,14 +101,17 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return (BulletData.ProjMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant)
+end
+
 if SERVER then
 	local Ballistics = ACF.Ballistics
 	local Entities   = Classes.Entities
-	local Conversion	= ACF.PointConversion
 
-	function Ammo:GetCost(BulletData)
-		return (BulletData.ProjMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant)
-	end
 
 	Entities.AddArguments("acf_ammo", "Flechettes", "Spread") -- Adding extra info to ammo crates
 

--- a/lua/acf/entities/ammo_types/fl.lua
+++ b/lua/acf/entities/ammo_types/fl.lua
@@ -322,9 +322,9 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_fl")
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
-			local FLMass	= ACF.GetProperMass(BulletData.FlechetteMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
+			local FLMass	= ACF.FormatMass(BulletData.FlechetteMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass, FLMass)
 		end)

--- a/lua/acf/entities/ammo_types/flare.lua
+++ b/lua/acf/entities/ammo_types/flare.lua
@@ -75,15 +75,17 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return ((BulletData.ProjMass - BulletData.FillerMass) * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.FlareMix)
+end
+
 if SERVER then
 	local Ballistics      = ACF.Ballistics
 	local Clock           = ACF.Utilities.Clock
 	local Countermeasures = ACF.Classes.Countermeasures
-	local Conversion	= ACF.PointConversion
-
-	function Ammo:GetCost(BulletData)
-		return ((BulletData.ProjMass - BulletData.FillerMass) * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.FlareMix)
-	end
 
 	function Ammo:Create(_, BulletData)
 		local Bullet = Ballistics.CreateBullet(BulletData)

--- a/lua/acf/entities/ammo_types/flare.lua
+++ b/lua/acf/entities/ammo_types/flare.lua
@@ -213,9 +213,9 @@ else
 
 			local Text		= "Muzzle Velocity : %s m/s\nProjectile Mass : %s\nPropellant Mass : %s\nFlare Filler Mass : %s"
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
-			local Filler	= ACF.GetProperMass(BulletData.FillerMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
+			local Filler	= ACF.FormatMass(BulletData.FillerMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass, Filler)
 		end)
@@ -226,7 +226,7 @@ else
 			self:UpdateRoundData(ToolData, BulletData)
 
 			local Text		= "Burn Rate : %s/s\nBurn Duration : %s s\nDistraction Chance : %s"
-			local Rate		= ACF.GetProperMass(BulletData.BurnRate)
+			local Rate		= ACF.FormatMass(BulletData.BurnRate)
 			local Duration	= math.Round(BulletData.BurnTime, 2)
 			local Chance	= math.Round(BulletData.DistractChance * 100, 2) .. "%"
 

--- a/lua/acf/entities/ammo_types/glatgm.lua
+++ b/lua/acf/entities/ammo_types/glatgm.lua
@@ -168,9 +168,9 @@ else
 			local PeakVel	= math.Round(Velocity * 0.5, 2)
 			local LaunchVel = math.Round(Velocity * 0.2, 2)
 			local Accel     = math.Round(math.Clamp(BulletData.ProjMass / BulletData.PropMass + BulletData.Caliber / 7, 0.2, 10), 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
-			local Filler	= ACF.GetProperMass(BulletData.FillerMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
+			local Filler	= ACF.FormatMass(BulletData.FillerMass)
 
 			return Text:format(PeakVel, LaunchVel, Accel, ProjMass, PropMass, Filler)
 		end)
@@ -184,7 +184,7 @@ else
 
 			local Text	   = "Blast Radius : %s m\nFragments : %s\nFragment Mass : %s\nFragment Velocity : %s m/s"
 			local Blast	   = math.Round(BulletData.BlastRadius, 2)
-			local FragMass = ACF.GetProperMass(BulletData.FragMass)
+			local FragMass = ACF.FormatMass(BulletData.FragMass)
 			local FragVel  = math.Round(BulletData.FragVel, 2)
 
 			return Text:format(Blast, BulletData.Fragments, FragMass, FragVel)

--- a/lua/acf/entities/ammo_types/he.lua
+++ b/lua/acf/entities/ammo_types/he.lua
@@ -74,13 +74,15 @@ function Ammo:BaseConvert(ToolData)
 	return Data, GUIData
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return ((BulletData.ProjMass - BulletData.FillerMass) * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.CompB)
+end
+
 if SERVER then
 	local Ballistics = ACF.Ballistics
-	local Conversion	= ACF.PointConversion
-
-	function Ammo:GetCost(BulletData)
-		return ((BulletData.ProjMass - BulletData.FillerMass) * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.CompB)
-	end
 
 	function Ammo:Network(Entity, BulletData)
 		Ammo.BaseClass.Network(self, Entity, BulletData)

--- a/lua/acf/entities/ammo_types/he.lua
+++ b/lua/acf/entities/ammo_types/he.lua
@@ -155,9 +155,9 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_he")
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
-			local Filler	= ACF.GetProperMass(BulletData.FillerMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
+			local Filler	= ACF.FormatMass(BulletData.FillerMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass, Filler)
 		end)
@@ -169,7 +169,7 @@ else
 
 			local Text	   = language.GetPhrase("acf.menu.ammo.filler_stats_he")
 			local Blast	   = math.Round(BulletData.BlastRadius, 2)
-			local FragMass = ACF.GetProperMass(BulletData.FragMass)
+			local FragMass = ACF.FormatMass(BulletData.FragMass)
 			local FragVel  = math.Round(BulletData.FragVel, 2)
 
 			return Text:format(Blast, BulletData.Fragments, FragMass, FragVel)

--- a/lua/acf/entities/ammo_types/heat.lua
+++ b/lua/acf/entities/ammo_types/heat.lua
@@ -218,17 +218,19 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return (BulletData.CasingMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.CompB) + (BulletData.LinerMass * Conversion.Copper)
+end
+
 if SERVER then
 	local Ballistics = ACF.Ballistics
 	local Entities   = Classes.Entities
 	local Objects    = Damage.Objects
-	local Conversion	= ACF.PointConversion
 
 	Entities.AddArguments("acf_ammo", "LinerAngleRatio", "StandoffRatio") -- Adding extra info to ammo crates
-
-	function Ammo:GetCost(BulletData)
-		return (BulletData.CasingMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.CompB) + (BulletData.LinerMass * Conversion.Copper)
-	end
 
 	function Ammo:OnLast(Entity)
 		Ammo.BaseClass.OnLast(self, Entity)

--- a/lua/acf/entities/ammo_types/heat.lua
+++ b/lua/acf/entities/ammo_types/heat.lua
@@ -610,9 +610,9 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_he")
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
-			local Filler	= ACF.GetProperMass(BulletData.FillerMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
+			local Filler	= ACF.FormatMass(BulletData.FillerMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass, Filler)
 		end)
@@ -628,7 +628,7 @@ else
 
 			local Text	   = language.GetPhrase("acf.menu.ammo.filler_stats_he")
 			local Blast	   = math.Round(BulletData.BlastRadius, 2)
-			local FragMass = ACF.GetProperMass(BulletData.FragMass)
+			local FragMass = ACF.FormatMass(BulletData.FragMass)
 			local FragVel  = math.Round(BulletData.FragVel, 2)
 
 			return Text:format(Blast, BulletData.Fragments, FragMass, FragVel)

--- a/lua/acf/entities/ammo_types/heatfs.lua
+++ b/lua/acf/entities/ammo_types/heatfs.lua
@@ -134,12 +134,14 @@ function Ammo:UpdateRoundData(ToolData, Data, GUIData)
 	end
 end
 
-if SERVER then
-	local Conversion	= ACF.PointConversion
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
 
-	function Ammo:GetCost(BulletData)
-		return (BulletData.CasingMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.Octol) + (BulletData.LinerMass * Conversion.Copper)
-	end
+function Ammo:GetCost(BulletData)
+	return (BulletData.CasingMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.Octol) + (BulletData.LinerMass * Conversion.Copper)
+end
+
+if SERVER then
 
 	function Ammo:Network(Entity, BulletData)
 		Ammo.BaseClass.Network(self, Entity, BulletData)

--- a/lua/acf/entities/ammo_types/hp.lua
+++ b/lua/acf/entities/ammo_types/hp.lua
@@ -70,17 +70,19 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	local RemovedMass	= BulletData.CavVol * ACF.SteelDensity
+
+	return (BulletData.ProjMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (RemovedMass * Conversion.Steel * 0.25)
+end
+
 if SERVER then
 	local Entities = Classes.Entities
-	local Conversion	= ACF.PointConversion
 
 	Entities.AddArguments("acf_ammo", "HollowRatio") -- Adding extra info to ammo crates
-
-	function Ammo:GetCost(BulletData)
-		local RemovedMass	= BulletData.CavVol * ACF.SteelDensity
-
-		return (BulletData.ProjMass * Conversion.Steel) + (BulletData.PropMass * Conversion.Propellant) + (RemovedMass * Conversion.Steel * 0.25)
-	end
 
 	function Ammo:OnLast(Entity)
 		Ammo.BaseClass.OnLast(self, Entity)

--- a/lua/acf/entities/ammo_types/hp.lua
+++ b/lua/acf/entities/ammo_types/hp.lua
@@ -194,8 +194,8 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_ap")
 			local MuzzleVel	= math.Round(BulletData.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(BulletData.ProjMass)
-			local PropMass	= ACF.GetProperMass(BulletData.PropMass)
+			local ProjMass	= ACF.FormatMass(BulletData.ProjMass)
+			local PropMass	= ACF.FormatMass(BulletData.PropMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass)
 		end)

--- a/lua/acf/entities/ammo_types/smoke.lua
+++ b/lua/acf/entities/ammo_types/smoke.lua
@@ -102,16 +102,18 @@ function Ammo:VerifyData(ToolData)
 	end
 end
 
+-- Shared with the client so the spawn menu can price a crate without spawning it.
+local Conversion = ACF.PointConversion
+
+function Ammo:GetCost(BulletData)
+	return ((BulletData.ProjMass - BulletData.FillerMass - BulletData.WPMass) * Conversion.Steel * 0.75) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.SF) + (BulletData.WPMass * Conversion.WP)
+end
+
 if SERVER then
 	local Ballistics = ACF.Ballistics
 	local Entities   = Classes.Entities
-	local Conversion	= ACF.PointConversion
 
 	Entities.AddArguments("acf_ammo", "FillerRatio", "SmokeWPRatio") -- Adding extra info to ammo crates
-
-	function Ammo:GetCost(BulletData)
-		return ((BulletData.ProjMass - BulletData.FillerMass - BulletData.WPMass) * Conversion.Steel * 0.75) + (BulletData.PropMass * Conversion.Propellant) + (BulletData.FillerMass * Conversion.SF) + (BulletData.WPMass * Conversion.WP)
-	end
 
 	function Ammo:OnLast(Entity)
 		Ammo.BaseClass.OnLast(self, Entity)

--- a/lua/acf/entities/ammo_types/smoke.lua
+++ b/lua/acf/entities/ammo_types/smoke.lua
@@ -336,8 +336,8 @@ else
 
 			local Text		= language.GetPhrase("acf.menu.ammo.round_stats_ap")
 			local MuzzleVel	= math.Round(Data.MuzzleVel * ACF.Scale, 2)
-			local ProjMass	= ACF.GetProperMass(Data.ProjMass)
-			local PropMass	= ACF.GetProperMass(Data.PropMass)
+			local ProjMass	= ACF.FormatMass(Data.ProjMass)
+			local PropMass	= ACF.FormatMass(Data.PropMass)
 
 			return Text:format(MuzzleVel, ProjMass, PropMass)
 		end)
@@ -352,7 +352,7 @@ else
 
 			if Data.FillerMass > 0 then
 				local Text		  = language.GetPhrase("acf.menu.ammo.smoke_stats")
-				local SmokeMass	  = ACF.GetProperMass(Data.FillerMass)
+				local SmokeMass	  = ACF.FormatMass(Data.FillerMass)
 				local SmokeRadius = (Data.SMRadiusMin + Data.SMRadiusMax) * 0.5
 
 				SMText = Text:format(SmokeMass, SmokeRadius, Data.SMLife)
@@ -360,7 +360,7 @@ else
 
 			if Data.WPMass > 0 then
 				local Text	   = language.GetPhrase("acf.menu.ammo.wp_stats")
-				local WPMass   = ACF.GetProperMass(Data.WPMass)
+				local WPMass   = ACF.FormatMass(Data.WPMass)
 				local WPRadius = (Data.WPRadiusMin + Data.WPRadiusMax) * 0.5
 
 				WPText = Text:format(WPMass, WPRadius, Data.WPLife)

--- a/lua/acf/entities/components/computers.lua
+++ b/lua/acf/entities/components/computers.lua
@@ -859,10 +859,10 @@ do -- GPS transmitter
 	})
 end
 
-local GroundLoaderText = "Mass : %s kg\n"
+local GroundLoaderText = "Mass : %s kg\nCost : %s\n"
 
 function ACF.CreateGroundLoaderMenu(Data, Menu)
-	Menu:AddLabel(GroundLoaderText:format(Data.Mass))
+	Menu:AddLabel(GroundLoaderText:format(Data.Mass, ACF.GetProperCost(ACF.GroundLoaderCost)))
 
 	ACF.SetClientData("PrimaryClass", "acf_groundloader")
 

--- a/lua/acf/entities/components/computers.lua
+++ b/lua/acf/entities/components/computers.lua
@@ -862,7 +862,7 @@ end
 local GroundLoaderText = "Mass : %s kg\nCost : %s\n"
 
 function ACF.CreateGroundLoaderMenu(Data, Menu)
-	Menu:AddLabel(GroundLoaderText:format(Data.Mass, ACF.GetProperCost(ACF.GroundLoaderCost)))
+	Menu:AddLabel(GroundLoaderText:format(Data.Mass, ACF.FormatCost(ACF.GroundLoaderCost)))
 
 	ACF.SetClientData("PrimaryClass", "acf_groundloader")
 

--- a/lua/acf/entities/components/computers.lua
+++ b/lua/acf/entities/components/computers.lua
@@ -43,7 +43,6 @@ if SERVER then
 
 	ACF.AddInputAction("acf_computer", "Lase", function(Entity, Value)
 		if Entity.Lasing == nil then return end
-		if Entity.OnCooldown then return end
 		if Entity.ACF.Health <= 0 then return end -- Destroyed
 
 		Value = tobool(Value)
@@ -72,13 +71,14 @@ if SERVER then
 end
 
 do -- Joystick
-	local MenuText = "Joystick bounds : +-%s degrees\nJoystick speed : %s degrees/s\nMass : %s kg"
+	local MenuText = "Joystick bounds : +-%s degrees\nJoystick speed : %s degrees/s\nMass : %s kg\nCost : %s"
 
 	Components.RegisterItem("CPR-Joystick", "GD-CPR", {
 		Name        = "Joystick",
 		Description = "A small joystick, used to manually guide anti-tank missiles and munitions.",
 		Model       = "models/weapons/w_slam.mdl",
 		Mass        = 7,
+		Cost        = 1,
 		MaxAngle    = 25,
 		Speed       = 50, -- Degrees per second
 		Offset      = Vector(0, -1.5, -0.25),
@@ -94,7 +94,7 @@ do -- Joystick
 			local Speed = Data.Speed
 			local Mass  = Data.Mass
 
-			Menu:AddLabel(MenuText:format(Angle, Speed, Mass))
+			Menu:AddLabel(MenuText:format(Angle, Speed, Mass, ACF.FormatCost(Data.Cost or 0)))
 
 			ACF.SetClientData("PrimaryClass", "acf_computer")
 		end,
@@ -266,7 +266,7 @@ do -- Joystick
 end
 
 do -- Optical guidance computer
-	local MenuText  = "Pitch bounds : +-%s degrees\nYaw bounds : +-%s degrees\nAim speed : %s degrees/s\nFocus speed : %s m/s\nMass : %s kg"
+	local MenuText  = "Pitch bounds : +-%s degrees\nYaw bounds : +-%s degrees\nAim speed : %s degrees/s\nFocus speed : %s m/s\nMass : %s kg\nCost : %s"
 	local TraceData = { start = true, endpos = true, filter = true }
 	local Computers = {}
 
@@ -292,6 +292,7 @@ do -- Optical guidance computer
 		Description = "Fully analog guidance computer. Unlike the laser guidance computer, it takes a few seconds for it to aim and focus properly.",
 		Model       = "models/props_lab/monitor01b.mdl",
 		Mass        = 43,
+		Cost        = 2,
 		Offset      = Vector(6, -1, 0),
 		Speed       = 10, -- Degrees per second
 		FocusSpeed  = 300, -- Meters per second
@@ -316,7 +317,7 @@ do -- Optical guidance computer
 			local Focus = Data.FocusSpeed
 			local Mass  = Data.Mass
 
-			Menu:AddLabel(MenuText:format(Pitch, Yaw, Speed, Focus, Mass))
+			Menu:AddLabel(MenuText:format(Pitch, Yaw, Speed, Focus, Mass, ACF.FormatCost(Data.Cost or 0)))
 
 			ACF.SetClientData("PrimaryClass", "acf_computer")
 		end,
@@ -420,7 +421,22 @@ do -- Optical guidance computer
 			Entity:TriggerInput("Yaw", 0)
 		end,
 		OnThink = function(Entity)
-			if Entity.ACF.Health <= 0 then return end -- Destroyed
+			if Entity.ACF.Health <= 0 then -- Destroyed
+				if Entity.Distance ~= 0 or Entity.HitPos ~= vector_origin then
+					Entity.Distance  = 0
+					Entity.HitPos    = Vector()
+					Entity.TraceDir  = Vector()
+					Entity.TracePos  = Entity.HitPos
+					Entity.TraceDist = Entity.Distance
+
+					WireLib.TriggerOutput(Entity, "Distance", 0)
+					WireLib.TriggerOutput(Entity, "HitPos", Vector())
+
+					Entity:UpdateOverlay()
+				end
+
+				return
+			end
 
 			local Tick  = engine.TickInterval()
 			local Speed = Entity.MoveSpeed * Tick * math.Rand(Entity.Spread, 1)
@@ -492,8 +508,7 @@ do -- Optical guidance computer
 end
 
 do -- Laser guidance computer
-	local MenuText  = "Pitch bounds : +-%s degrees\nYaw bounds : +-%s degrees\nAim speed : %s degrees/s\nMass : %s kg"
-	local LaserText = "Lasing time : %s seconds\nCooldown : %s seconds"
+	local MenuText  = "Pitch bounds : +-%s degrees\nYaw bounds : +-%s degrees\nAim speed : %s degrees/s\nMass : %s kg\nCost : %s"
 	local Clock     = ACF.Utilities.Clock
 
 	Components.RegisterItem("CPR-LSR", "GD-CPR", {
@@ -501,15 +516,12 @@ do -- Laser guidance computer
 		Description = "Modern equivalent to the analog guidance computer, provides faster and more accurate measurements. Can be also used as a laser target designator.",
 		Model       = "models/props_lab/monitor01b.mdl",
 		Mass        = 30,
-		LaseTime    = 20,
-		Cooldown    = 10,
+		Cost        = 4,
 		Offset      = Vector(6, -1, 0),
 		Speed       = 45, -- Degrees per second
 		Inputs      = { "Lase (Turns on the laser)", "Pitch (Degrees on the vertical axis)", "Yaw (Degrees on the horizontal axis)", "HitPos (Target location to aim laser at) [VECTOR]" },
 		Outputs     = {
 			"Lasing (Whether or not the laser is on)",
-			"Lase Time (How long the laser can stay on before requiring a cool down)",
-			"Cooling Down (Whether or not the laser is cooling off)",
 			"Distance (The currently measured distance from the computer, in meters)",
 			"HitPos (The vector of where the computer detects a hit from the laser) [VECTOR]",
 			"Current Pitch (Current degrees on the vertical axis)",
@@ -526,11 +538,8 @@ do -- Laser guidance computer
 			local Yaw      = Data.Bounds.Yaw
 			local Speed    = Data.Speed
 			local Mass     = Data.Mass
-			local LaseTime = Data.LaseTime
-			local Cooldown = Data.Cooldown
 
-			Menu:AddLabel(MenuText:format(Pitch, Yaw, Speed, Mass))
-			Menu:AddLabel(LaserText:format(LaseTime, Cooldown))
+			Menu:AddLabel(MenuText:format(Pitch, Yaw, Speed, Mass, ACF.FormatCost(Data.Cost or 0)))
 
 			ACF.SetClientData("PrimaryClass", "acf_computer")
 		end,
@@ -539,7 +548,6 @@ do -- Laser guidance computer
 			Entity.IsComputer = true
 			Entity.Lasing     = false
 			Entity.Offset     = Computer.Offset
-			Entity.OnCooldown = false
 			Entity.HitPos     = Vector()
 			Entity.Distance   = 0
 			Entity.TraceDir   = Vector()
@@ -547,10 +555,6 @@ do -- Laser guidance computer
 			Entity.TraceDist  = Entity.Distance
 			Entity.NextSpread = 0
 			Entity.Spread     = 0
-			Entity.LaseTime   = 0
-			Entity.LastLase   = 0
-			Entity.MaxTime    = Computer.LaseTime
-			Entity.Cooldown   = Computer.Cooldown
 			Entity.MoveSpeed  = Computer.Speed
 			Entity.MinPitch   = -Computer.Bounds.Pitch
 			Entity.MaxPitch   = Computer.Bounds.Pitch
@@ -572,8 +576,6 @@ do -- Laser guidance computer
 			})
 
 			WireLib.TriggerOutput(Entity, "Lasing", 0)
-			WireLib.TriggerOutput(Entity, "Lase Time", Entity.MaxTime)
-			WireLib.TriggerOutput(Entity, "Cooling Down", 0)
 			WireLib.TriggerOutput(Entity, "Distance", 0)
 			WireLib.TriggerOutput(Entity, "HitPos", Vector())
 			WireLib.TriggerOutput(Entity, "Current Pitch", 0)
@@ -582,7 +584,6 @@ do -- Laser guidance computer
 		OnLast = function(Entity)
 			Entity.IsComputer = nil
 			Entity.Lasing     = nil
-			Entity.OnCooldown = nil
 			Entity.HitPos     = nil
 			Entity.Distance   = nil
 			Entity.TraceDir   = nil
@@ -590,10 +591,6 @@ do -- Laser guidance computer
 			Entity.TraceDist  = nil
 			Entity.NextSpread = nil
 			Entity.Spread     = nil
-			Entity.LaseTime   = nil
-			Entity.LastLase   = nil
-			Entity.MaxTime    = nil
-			Entity.Cooldown   = nil
 			Entity.MoveSpeed  = nil
 			Entity.MinPitch   = nil
 			Entity.MaxPitch   = nil
@@ -610,7 +607,6 @@ do -- Laser guidance computer
 		end,
 		OnOverlayTitle = function(Entity)
 			if not Entity.IsComputer then return end
-			if Entity.OnCooldown then return "Cooling down" end
 			if Entity.Lasing then return "Lasing" end
 			if Entity.InputPitch ~= 0 or Entity.InputYaw ~= 0 then
 				return "In use"
@@ -664,6 +660,18 @@ do -- Laser guidance computer
 					Entity:SetNW2Bool("Lasing", false)
 
 					WireLib.TriggerOutput(Entity, "Lasing", 0)
+				end
+
+				if Entity.Distance ~= 0 or Entity.HitPos ~= vector_origin then
+					Entity.Distance  = 0
+					Entity.HitPos    = Vector()
+					Entity.TraceDir  = Vector()
+					Entity.TracePos  = Entity.HitPos
+					Entity.TraceDist = Entity.Distance
+
+					WireLib.TriggerOutput(Entity, "Distance", 0)
+					WireLib.TriggerOutput(Entity, "HitPos", Vector())
+
 					Entity:UpdateOverlay()
 				end
 
@@ -720,55 +728,28 @@ do -- Laser guidance computer
 				end
 			end
 
-			if Entity.Lasing or Entity.LaseTime > 0 then
-				local Delta = math.min(Clock.CurTime - Entity.LastLase, Tick) * (Entity.Lasing and 1 or -1)
+			if Entity.Lasing then
+				local Laser = ACF.GetLaserData(Entity)
 
-				Entity.LaseTime = math.Clamp(Entity.LaseTime + Delta, 0, Entity.MaxTime)
+				Entity.Distance  = Laser and Laser.Distance or 0
+				Entity.HitPos    = Laser and Laser.HitPos or Vector()
+				Entity.TraceDir  = Laser and Laser.Trace.Normal
+				Entity.TracePos  = Entity.HitPos
+				Entity.TraceDist = Entity.Distance
 
-				if Entity.LaseTime == Entity.MaxTime then
-					Entity:TriggerInput("Lase", 0)
+				WireLib.TriggerOutput(Entity, "Distance", Entity.Distance)
+				WireLib.TriggerOutput(Entity, "HitPos", Entity.HitPos)
 
-					Entity.OnCooldown = true
-					Entity.HitPos     = Vector()
-					Entity.Distance   = 0
-					Entity.LaseTime   = 0
-					Entity.TraceDir   = Vector()
-					Entity.TracePos   = Entity.HitPos
-					Entity.TraceDist  = Entity.Distance
+				Entity:UpdateOverlay()
+			elseif Entity.Distance ~= 0 or Entity.HitPos ~= vector_origin then -- Just turned off, clear the last reading
+				Entity.Distance  = 0
+				Entity.HitPos    = Vector()
+				Entity.TraceDir  = Vector()
+				Entity.TracePos  = Entity.HitPos
+				Entity.TraceDist = Entity.Distance
 
-					WireLib.TriggerOutput(Entity, "Cooling Down", 1)
-					WireLib.TriggerOutput(Entity, "HitPos", Vector())
-					WireLib.TriggerOutput(Entity, "Distance", 0)
-
-					timer.Simple(Entity.Cooldown, function()
-						if not IsValid(Entity) then return end
-
-						Entity.OnCooldown = false
-
-						if Entity.Inputs.Lase.Path then
-							Entity:TriggerInput("Lase", Entity.Inputs.Lase.Value)
-						end
-
-						WireLib.TriggerOutput(Entity, "Cooling Down", 0)
-
-						Entity:UpdateOverlay()
-					end)
-				else
-					local Laser = ACF.GetLaserData(Entity)
-
-					Entity.Distance  = Laser and Laser.Distance or 0
-					Entity.HitPos    = Laser and Laser.HitPos or Vector()
-					Entity.TraceDir  = Laser and Laser.Trace.Normal
-					Entity.TracePos  = Entity.HitPos
-					Entity.TraceDist = Entity.Distance
-
-					WireLib.TriggerOutput(Entity, "Distance", Entity.Distance)
-					WireLib.TriggerOutput(Entity, "HitPos", Entity.HitPos)
-				end
-
-				WireLib.TriggerOutput(Entity, "Lase Time", Entity.MaxTime - Entity.LaseTime)
-
-				Entity.LastLase = Clock.CurTime
+				WireLib.TriggerOutput(Entity, "Distance", 0)
+				WireLib.TriggerOutput(Entity, "HitPos", Vector())
 
 				Entity:UpdateOverlay()
 			end
@@ -784,6 +765,7 @@ do -- GPS transmitter
 		Description = "A transmitter for GPS-based guided munitions.",
 		Model       = "models/props_lab/reciever01a.mdl",
 		Mass        = 15,
+		Cost        = 2,
 		Inputs      = { "Coordinates (The vector to pass along to the linked rack) [VECTOR]" },
 		Outputs     = {
 			"Transmitting (Whether or not the transmitter is functioning)",
@@ -793,7 +775,7 @@ do -- GPS transmitter
 			FOV = 80,
 		},
 		CreateMenu = function(Data, Menu)
-			Menu:AddLabel("Mass : " .. Data.Mass .. " kg")
+			Menu:AddLabel("Mass : " .. Data.Mass .. " kg\nCost : " .. ACF.FormatCost(Data.Cost or 0))
 			--Menu:AddLabel("This entity can be jammed.") -- Not yet
 
 			ACF.SetClientData("PrimaryClass", "acf_computer")

--- a/lua/acf/entities/components/radarsync.lua
+++ b/lua/acf/entities/components/radarsync.lua
@@ -20,7 +20,7 @@ Components.RegisterItem("RadarSync-Item", "RadarSync", {
 		FOV = 90,
 	},
 	CreateMenu = function(Data, Menu)
-		Menu:AddLabel("Mass : " .. Data.Mass .. " kg\nCost : " .. ACF.GetProperCost(ACF.RadarSyncCost) .. "\n\nLink this entity to radar entities to combine their detection zones into this entity's outputs.")
+		Menu:AddLabel("Mass : " .. Data.Mass .. " kg\nCost : " .. ACF.FormatCost(ACF.RadarSyncCost) .. "\n\nLink this entity to radar entities to combine their detection zones into this entity's outputs.")
 
 		ACF.SetClientData("PrimaryClass", "acf_radarsync")
 	end,

--- a/lua/acf/entities/components/radarsync.lua
+++ b/lua/acf/entities/components/radarsync.lua
@@ -20,7 +20,7 @@ Components.RegisterItem("RadarSync-Item", "RadarSync", {
 		FOV = 90,
 	},
 	CreateMenu = function(Data, Menu)
-		Menu:AddLabel("Mass : " .. Data.Mass .. " kg\n\nLink this entity to radar entities to combine their detection zones into this entity's outputs.")
+		Menu:AddLabel("Mass : " .. Data.Mass .. " kg\nCost : " .. ACF.GetProperCost(ACF.RadarSyncCost) .. "\n\nLink this entity to radar entities to combine their detection zones into this entity's outputs.")
 
 		ACF.SetClientData("PrimaryClass", "acf_radarsync")
 	end,

--- a/lua/acf/entities/components/supplies.lua
+++ b/lua/acf/entities/components/supplies.lua
@@ -60,7 +60,7 @@ Components.RegisterItem("RFL-UNIT", "SP-RFL", {
 			local Capacity = Volume * ACF.gCmToKgIn
 			local TransferRate = ACF.SupplyMassRate * (Volume / 1000)
 
-			CapacityLabel:SetText(string.format("Capacity : %s kg\nTransfer Rate : %s kg/s", math.Round(Capacity, 2), math.Round(TransferRate, 2)))
+			CapacityLabel:SetText(string.format("Capacity : %s kg\nTransfer Rate : %s kg/s\nMass (full) : %s\nCost : %s", math.Round(Capacity, 2), math.Round(TransferRate, 2), ACF.GetProperMass(Capacity), ACF.GetProperCost(Capacity * 0.01)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(SupplySize)

--- a/lua/acf/entities/components/supplies.lua
+++ b/lua/acf/entities/components/supplies.lua
@@ -60,7 +60,7 @@ Components.RegisterItem("RFL-UNIT", "SP-RFL", {
 			local Capacity = Volume * ACF.gCmToKgIn
 			local TransferRate = ACF.SupplyMassRate * (Volume / 1000)
 
-			CapacityLabel:SetText(string.format("Capacity : %s kg\nTransfer Rate : %s kg/s\nMass (full) : %s\nCost : %s", math.Round(Capacity, 2), math.Round(TransferRate, 2), ACF.GetProperMass(Capacity), ACF.GetProperCost(Capacity * 0.01)))
+			CapacityLabel:SetText(string.format("Capacity : %s kg\nTransfer Rate : %s kg/s\nMass (full) : %s\nCost : %s", math.Round(Capacity, 2), math.Round(TransferRate, 2), ACF.FormatMass(Capacity), ACF.FormatCost(Capacity * 0.01)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(SupplySize)

--- a/lua/acf/entities/fuel_types/electric.lua
+++ b/lua/acf/entities/fuel_types/electric.lua
@@ -16,7 +16,7 @@ FuelTypes.Register("Electric", {
 		local kWh = math.Round(Capacity * ACF.LiIonED, 2)
 		local MJ = math.Round(Capacity * ACF.LiIonED * 3.6, 2)
 
-		return Text:format(kWh, MJ, ACF.GetProperMass(Mass))
+		return Text:format(kWh, MJ, ACF.FormatMass(Mass))
 	end,
 
 	FuelTankOverlay	= function(Fuel, State)

--- a/lua/acf/entities/fuzes/altitude.lua
+++ b/lua/acf/entities/fuzes/altitude.lua
@@ -3,13 +3,14 @@ local Classes = ACF.Classes
 local Fuzes   = Classes.Fuzes
 local Fuze    = Fuzes.Register("Altitude", "Contact")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Fuze:GetCost()
+	return 0.1
+end
+
 if CLIENT then
 	Fuze.Description = "This fuze tracks the guidance module's target and detonates once it crosses the altitude of the target position."
 else
-	function Fuze:GetCost()
-		return 0.1
-	end
-
 	function Fuze:GetDetonate(Missile, Guidance)
 		if not self:IsArmed() or not Guidance then return false end
 

--- a/lua/acf/entities/fuzes/contact.lua
+++ b/lua/acf/entities/fuzes/contact.lua
@@ -23,6 +23,11 @@ function Fuze:WriteDisplayConfig(State)
 	State:AddSubKeyValue("Primer", math.Round(self.Primer, 2))
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Fuze:GetCost()
+	return 0
+end
+
 if CLIENT then
 	Fuze.Description = "This fuze triggers upon direct contact against solid surfaces."
 
@@ -41,10 +46,6 @@ else
 	local Entities = Classes.Entities
 
 	Entities.AddArguments("acf_ammo", "ArmingDelay") -- Adding extra info to ammo crates
-
-	function Fuze:GetCost()
-		return 0
-	end
 
 	function Fuze:VerifyData(_, Data)
 		local Delay = Data.ArmingDelay

--- a/lua/acf/entities/fuzes/optical.lua
+++ b/lua/acf/entities/fuzes/optical.lua
@@ -11,6 +11,11 @@ function Fuze:WriteDisplayConfig(State)
 	State:AddSubKeyValue("Distance", math.Round(self.Distance * ACF.InchToMeter, 2) .. " m")
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Fuze:GetCost()
+	return 1
+end
+
 if CLIENT then
 	Fuze.Description = "This fuze fires a beam directly ahead and detonates when the beam hits something close-by. Distance in inches."
 
@@ -31,10 +36,6 @@ else
 	local Trace     = ACF.trace
 
 	Entities.AddArguments("acf_ammo", "FuzeDistance") -- Adding extra info to ammo crates
-
-	function Fuze:GetCost()
-		return 1
-	end
 
 	function Fuze:VerifyData(EntClass, Data, ...)
 		Fuze.BaseClass.VerifyData(self, EntClass, Data, ...)

--- a/lua/acf/entities/fuzes/radio.lua
+++ b/lua/acf/entities/fuzes/radio.lua
@@ -1,13 +1,14 @@
 local Fuzes = ACF.Classes.Fuzes
 local Fuze  = Fuzes.Register("Radio", "Optical")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Fuze:GetCost()
+	return 1
+end
+
 if CLIENT then
 	Fuze.Description = "This fuze tracks the Guidance module's target and detonates when the distance becomes low enough.\nDistance in inches."
 else
-	function Fuze:GetCost()
-		return 1
-	end
-
 	function Fuze:GetDetonate(Missile, Guidance)
 		if not self:IsArmed() then return false end
 

--- a/lua/acf/entities/guidance/active_radar.lua
+++ b/lua/acf/entities/guidance/active_radar.lua
@@ -2,13 +2,14 @@ local ACF       = ACF
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("Active Radar", "Semi-Active Radar")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 5
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package uses a radar to detect contraptions and guides the munition towards the most centered one it can find."
 else
-	function Guidance:GetCost()
-		return 5
-	end
-
 	function Guidance:SeekTarget(Missile)
 		local Position   = Missile.ACF_Position
 		local Targets    = ACF.GetEntitiesInCone(Position, Missile:GetForward(), self.SeekCone)

--- a/lua/acf/entities/guidance/antimissile.lua
+++ b/lua/acf/entities/guidance/antimissile.lua
@@ -1,14 +1,15 @@
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("Anti-missile", "Anti-radiation")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 3
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package uses a radar to detect missiles and guides the munition towards the most centered one it can find."
 else
 	local Countermeasures = ACF.Classes.Countermeasures
-
-	function Guidance:GetCost()
-		return 3
-	end
 
 	function Guidance:GetRadar()
 		if not IsValid(self.Source) then return end

--- a/lua/acf/entities/guidance/antiradiation.lua
+++ b/lua/acf/entities/guidance/antiradiation.lua
@@ -14,16 +14,17 @@ function Guidance:WriteDisplayConfig(State)
 	State:AddSubKeyValue("Seeking",  math.Round(self.ViewCone * 2, 2) .. " degrees")
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 4
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package will detect an active radar infront of itself and guide the munition towards it."
 else
 	local Radars = ACF.ActiveRadars
 
 	Guidance.MinDistance = 38750 -- Squared, ~5 meters
-
-	function Guidance:GetCost()
-		return 4
-	end
 
 	function Guidance:UpdateTarget(Missile)
 		if not next(Radars) then return end

--- a/lua/acf/entities/guidance/dumb.lua
+++ b/lua/acf/entities/guidance/dumb.lua
@@ -11,14 +11,15 @@ function Guidance:WriteDisplayConfig()
 
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 0
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package is empty and provides no control."
 else
 	local Countermeasures = ACF.Classes.Countermeasures
-
-	function Guidance:GetCost()
-		return 0
-	end
 
 	function Guidance:OnLaunched() end
 

--- a/lua/acf/entities/guidance/gps.lua
+++ b/lua/acf/entities/guidance/gps.lua
@@ -2,13 +2,14 @@ local ACF       = ACF
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("GPS Guided", "Radio (MCLOS)")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 2
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package allows you to guide the munition to a desired point in the map."
 else
-	function Guidance:GetCost()
-		return 2
-	end
-
 	function Guidance:OnLaunched(Missile)
 		Guidance.BaseClass.OnLaunched(self, Missile)
 

--- a/lua/acf/entities/guidance/infrared.lua
+++ b/lua/acf/entities/guidance/infrared.lua
@@ -2,13 +2,14 @@ local ACF       = ACF
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("Infrared", "Anti-radiation")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 3
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package will detect a contraption in front of itself and guide the munition towards it."
 else
-	function Guidance:GetCost()
-		return 3
-	end
-
 	function Guidance:UpdateTarget(Missile)
 		local Position   = Missile.ACF_Position
 		local Targets    = ACF.GetEntitiesInCone(Position, Missile:GetForward(), self.SeekCone)

--- a/lua/acf/entities/guidance/laser.lua
+++ b/lua/acf/entities/guidance/laser.lua
@@ -13,16 +13,17 @@ function Guidance:WriteDisplayConfig(State)
 	State:AddSubKeyValue("Tracking", math.Round(self.ViewCone * 2, 2) .. " deg")
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 5
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package reads a target-position from the launcher and guides the munition towards it."
 else
 	local TraceData = { start = true, endpos = true, mask = MASK_SOLID_BRUSHONLY, filter = {} }
 	local Trace     = ACF.trace
 	local Lasers    = ACF.ActiveLasers
-
-	function Guidance:GetCost()
-		return 5
-	end
 
 	function Guidance.GetDirectionDot(Missile, TargetPos)
 		local Position = Missile.ACF_Position

--- a/lua/acf/entities/guidance/radio_mclos.lua
+++ b/lua/acf/entities/guidance/radio_mclos.lua
@@ -5,15 +5,16 @@ function Guidance:Configure(Missile)
 	self.Source = Missile.Launcher
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 4
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package allows you to manually control the direction of the missile."
 else
 	local TraceData = { start = true, endpos = true, mask = MASK_SOLID_BRUSHONLY }
 	local Trace     = ACF.trace
-
-	function Guidance:GetCost()
-		return 4
-	end
 
 	function Guidance:OnLaunched(Missile)
 		self.InPos = Missile.MountPoint.Position

--- a/lua/acf/entities/guidance/radio_saclos.lua
+++ b/lua/acf/entities/guidance/radio_saclos.lua
@@ -1,14 +1,15 @@
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("Radio (SACLOS)", "Radio (MCLOS)")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 5
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package allows you to control the direction of the missile using a computer's aiming position."
 else
 	local ZERO = Vector()
-
-	function Guidance:GetCost()
-		return 5
-	end
 
 	function Guidance:CheckComputer()
 		local Computer = self:GetComputer()

--- a/lua/acf/entities/guidance/semi_active_radar.lua
+++ b/lua/acf/entities/guidance/semi_active_radar.lua
@@ -1,13 +1,14 @@
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("Semi-Active Radar", "Anti-missile")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 5
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package uses a radar to detect contraptions and guides the munition towards the most centered one it can find."
 else
-	function Guidance:GetCost()
-		return 5
-	end
-
 	-- Semi-actives can't seek targets by themselves
 	function Guidance:SeekTarget()
 		self.Target  = nil

--- a/lua/acf/entities/guidance/wire_mclos.lua
+++ b/lua/acf/entities/guidance/wire_mclos.lua
@@ -13,16 +13,17 @@ function Guidance:WriteDisplayConfig(State)
 	State:AddSubKeyValue("Wire Length", math.Round(self.WireLength ^ 0.5 * ACF.InchToMeter, 2) .. " meters")
 end
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 4
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package allows you to manually control the direction of the missile."
 else
 	local SnapSound = "physics/metal/sawblade_stick%s.wav"
 
 	Guidance.IsWire = true
-
-	function Guidance:GetCost()
-		return 4
-	end
 
 	function Guidance:OnLaunched(Missile)
 		Guidance.BaseClass.OnLaunched(self, Missile)

--- a/lua/acf/entities/guidance/wire_saclos.lua
+++ b/lua/acf/entities/guidance/wire_saclos.lua
@@ -1,14 +1,15 @@
 local Guidances = ACF.Classes.Guidances
 local Guidance  = Guidances.Register("Wire (SACLOS)", "Wire (MCLOS)")
 
+-- Shared so the ammo menu can price missile rounds clientside.
+function Guidance:GetCost()
+	return 5
+end
+
 if CLIENT then
 	Guidance.Description = "This guidance package allows you to control the direction of the missile using a computer's aiming position."
 else
 	local ZERO = Vector()
-
-	function Guidance:GetCost()
-		return 5
-	end
 
 	function Guidance:CheckComputer()
 		local Computer = self:GetComputer()

--- a/lua/acf/entities/sensors/radars/radar.lua
+++ b/lua/acf/entities/sensors/radars/radar.lua
@@ -42,6 +42,7 @@ do -- Directional radars
 		Description	= "A lightweight directional radar with a shorter detection range and coarser target resolution.",
 		Model		= "models/radar/radar_sml.mdl",
 		Mass		= 35,
+		Cost		= 12.5,
 		ViewCone	= 60,
 		Range		= 23622, -- ~600m
 		MinSizeAtRange = 24,
@@ -59,6 +60,7 @@ do -- Directional radars
 		Description	= "A directional radar with a moderate detection range and target resolution.",
 		Model		= "models/radar/radar_mid.mdl",
 		Mass		= 120,
+		Cost		= 25,
 		ViewCone	= 60,
 		Range		= 31496, -- ~800m
 		MinSizeAtRange = 14,
@@ -76,6 +78,7 @@ do -- Directional radars
 		Description	= "A heavy directional radar with a longer detection range and finer target resolution.",
 		Model		= "models/radar/radar_big.mdl",
 		Mass		= 220,
+		Cost		= 50,
 		ViewCone	= 60,
 		Range		= 39370, -- ~1000m
 		MinSizeAtRange = 7,
@@ -119,6 +122,7 @@ do -- Spherical radars
 		Description	= "A lightweight omni-directional radar with a shorter detection range and coarser target resolution.",
 		Model		= "models/radar/radar_sp_sml.mdl",
 		Mass		= 80,
+		Cost		= 20,
 		Range		= 18898, -- ~480m
 		MinSizeAtRange = 24,
 		Origin		= "radar",
@@ -135,6 +139,7 @@ do -- Spherical radars
 		Description	= "An omni-directional radar with a moderate detection range and target resolution.",
 		Model		= "models/radar/radar_sp_mid.mdl",
 		Mass		= 210,
+		Cost		= 40,
 		Range		= 25197, -- ~640m
 		MinSizeAtRange = 14,
 		Origin		= "radar",
@@ -151,6 +156,7 @@ do -- Spherical radars
 		Description	= "A heavy omni-directional radar with a longer detection range and finer target resolution.",
 		Model		= "models/radar/radar_sp_big.mdl",
 		Mass		= 540,
+		Cost		= 80,
 		Range		= 31496, -- ~800m
 		MinSizeAtRange = 7,
 		Origin		= "radar",

--- a/lua/acf/entities/sensors/receivers/receivers.lua
+++ b/lua/acf/entities/sensors/receivers/receivers.lua
@@ -60,6 +60,7 @@ do -- Laser Receiver
 		Model		= "models/bluemetaknight/laser_detector.mdl",
 
 		Mass		= 25,
+		Cost		= 1.5,
 		Health		= 10,
 		Armor		= 10,
 		Offset 		= Vector(0, 0, 3),
@@ -125,6 +126,7 @@ do -- Radar Receiver
 		Model		= "models/jaanus/wiretool/wiretool_siren.mdl",
 
 		Mass		= 25,
+		Cost		= 4,
 		Health		= 10,
 		Armor		= 10,
 		Offset 		= Vector(0, 0, 6),

--- a/lua/acf/entities/sensors/sensors_menu_cl.lua
+++ b/lua/acf/entities/sensors/sensors_menu_cl.lua
@@ -29,7 +29,7 @@ do	-- Radars
 				Cost = Cost - ACF.RadarSingleTypeDiscount
 			end
 
-			Stats:SetText(Text:format(ViewCone, ViewRange, MinSize, Data.Mass, ACF.GetProperCost(Cost)))
+			Stats:SetText(Text:format(ViewCone, ViewRange, MinSize, Data.Mass, ACF.FormatCost(Cost)))
 		end
 
 		UpdateStats()

--- a/lua/acf/entities/sensors/sensors_menu_cl.lua
+++ b/lua/acf/entities/sensors/sensors_menu_cl.lua
@@ -1,7 +1,7 @@
 local ACF  = ACF
 
 do	-- Radars
-	local Text = "View Cone : %s degrees\nView Range : %s\nMin. Target Size (at max range) : %s\nMass : %s kg\n"
+	local Text = "View Cone : %s degrees\nView Range : %s\nMin. Target Size (at max range) : %s\nMass : %s kg\nCost : %s\n"
 	local SizeColor = Color(255, 0, 0)
 	local FormulaText = "The minimum target size a radar can detect shrinks the closer a target gets. Smaller radars can only see small targets up close, while larger radars can see small targets much further out. A target smaller than the curve at its current distance won't be detected.\n\nMinimum detectable size = Min. Target Size x (Distance / View Range) ^ 2"
 	local DetectTypesText = "Radars can be set to detect Contraptions, Missiles, or both. Radars that can only detect one target type receive a slight cost discount."
@@ -19,7 +19,20 @@ do	-- Radars
 		local ViewRange = Data.Range and (math.Round(Data.Range * ACF.InchToMeter) .. " m") or "Unlimited"
 		local MinSize = Data.MinSizeAtRange and (Data.MinSizeAtRange .. " in") or "N/A"
 
-		Menu:AddLabel(Text:format(ViewCone, ViewRange, MinSize, Data.Mass))
+		local Stats = Menu:AddLabel("")
+
+		-- A radar detecting only one target type is discounted, so cost follows the checkboxes.
+		local function UpdateStats()
+			local Cost = Data.Cost or 0
+
+			if ACF.GetClientBool("DetectContraptions", true) ~= ACF.GetClientBool("DetectMissiles", true) then
+				Cost = Cost - ACF.RadarSingleTypeDiscount
+			end
+
+			Stats:SetText(Text:format(ViewCone, ViewRange, MinSize, Data.Mass, ACF.GetProperCost(Cost)))
+		end
+
+		UpdateStats()
 
 		ACF.SetClientData("PrimaryClass", "acf_radar")
 
@@ -63,6 +76,7 @@ do	-- Radars
 			end
 
 			ACF.SetClientData("DetectContraptions", Value)
+			UpdateStats()
 		end
 
 		function DetectMissiles:OnChange(Value)
@@ -71,6 +85,7 @@ do	-- Radars
 			end
 
 			ACF.SetClientData("DetectMissiles", Value)
+			UpdateStats()
 		end
 
 		-- Triggered once on menu creation and every time either checkbox is toggled.

--- a/lua/acf/entities/sensors/sensors_menu_cl.lua
+++ b/lua/acf/entities/sensors/sensors_menu_cl.lua
@@ -95,11 +95,11 @@ do	-- Radars
 end
 
 do	-- Receivers
-	local Text = "Mass : %s kg\n"
+	local Text = "Mass : %s kg\nCost : %s\n"
 
 	function ACF.CreateReceiverMenu(Data, Menu)
 
-		Menu:AddLabel(Text:format(Data.Mass))
+		Menu:AddLabel(Text:format(Data.Mass, ACF.FormatCost(Data.Cost or 0)))
 
 		ACF.SetClientData("PrimaryClass", "acf_receiver")
 	end

--- a/lua/acf/entities/weapons/grenadelauncher.lua
+++ b/lua/acf/entities/weapons/grenadelauncher.lua
@@ -44,7 +44,7 @@ Weapons.Register("GL", {
 		Amount = 4,
 		Text = "Maximum amount of ACF grenade launchers a player can create."
 	},
-	CostScalar	= 0.5
+	CostScalar	= 0.38
 })
 
 ACF.SetCustomAttachment("models/launcher/40mmgl.mdl", "muzzle", Vector(19), Angle(0, 0, -180))

--- a/lua/acf/entities/weapons/howitzer.lua
+++ b/lua/acf/entities/weapons/howitzer.lua
@@ -33,7 +33,7 @@ Weapons.Register("HW", {
 			{Name = "Breech", LPos = Vector(-47.538, 0, -1.35938), LAng = Angle(0, 0, 0), Width = 7.992125984252, Height = 7.992125984252},
 		}
 	},
-	CostScalar	= 0.5
+	CostScalar	= 0.32
 })
 
 ACF.SetCustomAttachment("models/howitzer/howitzer_105mm.mdl", "muzzle", Vector(101.08, 0, -1.08))

--- a/lua/acf/entities/weapons/lightautocannon.lua
+++ b/lua/acf/entities/weapons/lightautocannon.lua
@@ -53,7 +53,7 @@ Weapons.Register("LAC", {
 		Amount = 4,
 		Text = "Maximum amount of ACF light auto cannons a player can create."
 	},
-	CostScalar	= 0.5
+	CostScalar	= 0.6
 })
 
 ACF.SetCustomAttachments("models/machinegun/machinegun_40mm_compact.mdl", {

--- a/lua/acf/entities/weapons/machinegun.lua
+++ b/lua/acf/entities/weapons/machinegun.lua
@@ -47,7 +47,7 @@ Weapons.Register("MG", {
 		Amount = 4,
 		Text = "Maximum amount of ACF machine guns a player can create."
 	},
-	CostScalar	= 0.25
+	CostScalar	= 0.4
 })
 
 ACF.SetCustomAttachment("models/machinegun/machinegun_20mm.mdl", "muzzle", Vector(53.05, 0, -0.11), Angle(0, 0, 90))

--- a/lua/acf/entities/weapons/mortar.lua
+++ b/lua/acf/entities/weapons/mortar.lua
@@ -35,7 +35,7 @@ Weapons.Register("MO", {
 			{Name = "Barrel", LPos = Vector(37.0706, 0, 0.015625), LAng = Angle(180, 0, 0), Width = 11.023622047244, Height = 11.023622047244},
 		}
 	},
-	CostScalar	= 0.35
+	CostScalar	= 0.29
 })
 
 ACF.SetCustomAttachment("models/mortar/mortar_120mm.mdl", "muzzle", Vector(24.02), Angle(0, 0, 90))

--- a/lua/acf/entities/weapons/shortcannon.lua
+++ b/lua/acf/entities/weapons/shortcannon.lua
@@ -37,7 +37,7 @@ Weapons.Register("SC", {
 			{Name = "Breech", LPos = Vector(-40.8958, 0, 0.015625), LAng = Angle(0, 0, 0), Width = 6.6929133858268, Height = 6.6929133858268},
 		}
 	},
-	CostScalar	= 0.275
+	CostScalar	= 0.26
 })
 
 ACF.SetCustomAttachment("models/tankgun/tankgun_short_100mm.mdl", "muzzle", Vector(82.86, -0.01), Angle(0, 0, 90))

--- a/lua/acf/menu/items_cl/ammo_menu.lua
+++ b/lua/acf/menu/items_cl/ammo_menu.lua
@@ -379,6 +379,25 @@ local function AddControls(Base, ToolData)
 	AmmoStage:SetValue(1)
 end
 
+---Returns the point cost of a single round, mirroring acf_ammo's GetRoundCost.
+---Guidance and fuze are read live rather than from a ToolData snapshot, since
+---they can change without the surrounding menu being rebuilt.
+---@return number Cost The cost of one round in points.
+local function GetRoundCost()
+	local Cost = Ammo:GetCost(BulletData)
+
+	-- Only missile ammo carries guidance and fuze, and both are charged per round.
+	if ACF.GetClientString("Destiny") ~= "Missiles" then return Cost end
+
+	local Guidance = Classes.Guidances.Get(ACF.GetClientString("Guidance"))
+	local Fuze     = Classes.Fuzes.Get(ACF.GetClientString("Fuze"))
+
+	if Guidance then Cost = Cost + Guidance:GetCost() end
+	if Fuze then Cost = Cost + Fuze:GetCost() end
+
+	return Cost
+end
+
 ---Creates the ammunition information panels on the ACF menu.
 ---@param Base userdata The panel being populated with the ammunition information.
 ---This function makes use of SuppressInformation and SuppressCrateInformation
@@ -409,6 +428,9 @@ local function AddCrateInformation(Base, ToolData)
 	Crate:TrackClientData("PropRatio")
 	Crate:TrackClientData("CaseScale")
 	Crate:TrackClientData("Tracer")
+	-- Missile ammo folds guidance and fuze cost into every round
+	Crate:TrackClientData("Guidance")
+	Crate:TrackClientData("Fuze")
 	Crate:DefineSetter(function()
 		UpdateBoxSizeFromProjectileCounts(ToolData, BulletData)
 
@@ -425,8 +447,9 @@ local function AddCrateInformation(Base, ToolData)
 		-- CartMass is the mass of a whole round, so it multiplies complete rounds, not cells
 		local Load      = math.floor(BulletData.CartMass * Rounds)
 		local Mass      = ACF.GetProperMass(Load)
+		local Cost      = ACF.GetProperCost(Rounds * GetRoundCost())
 
-		return CrateText:format(Mass, Rounds)
+		return CrateText:format(Mass, Cost, Rounds)
 	end)
 
 	if Ammo.OnCreateCrateInformation then

--- a/lua/acf/menu/items_cl/ammo_menu.lua
+++ b/lua/acf/menu/items_cl/ammo_menu.lua
@@ -446,8 +446,8 @@ local function AddCrateInformation(Base, ToolData)
 
 		-- CartMass is the mass of a whole round, so it multiplies complete rounds, not cells
 		local Load      = math.floor(BulletData.CartMass * Rounds)
-		local Mass      = ACF.GetProperMass(Load)
-		local Cost      = ACF.GetProperCost(Rounds * GetRoundCost())
+		local Mass      = ACF.FormatMass(Load)
+		local Cost      = ACF.FormatCost(Rounds * GetRoundCost())
 
 		return CrateText:format(Mass, Cost, Rounds)
 	end)

--- a/lua/acf/menu/items_cl/autoloaders.lua
+++ b/lua/acf/menu/items_cl/autoloaders.lua
@@ -26,8 +26,8 @@ Components.RegisterItem("AL-IMP", "AL", {
 			local R, H = AutoloaderSize.y, AutoloaderSize.x
 			local Volume = math.pi * R * R * H
 
-			MassLabel:SetText(string.format("Mass : %s", ACF.GetProperMass(Volume * 250)))
-			CostLabel:SetText(string.format("Cost : %s", ACF.GetProperCost(Volume * 8)))
+			MassLabel:SetText(string.format("Mass : %s", ACF.FormatMass(Volume * 250)))
+			CostLabel:SetText(string.format("Cost : %s", ACF.FormatCost(Volume * 8)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(AutoloaderSize, true)

--- a/lua/acf/menu/items_cl/autoloaders.lua
+++ b/lua/acf/menu/items_cl/autoloaders.lua
@@ -18,6 +18,7 @@ Components.RegisterItem("AL-IMP", "AL", {
 		ACF.SetClientData("SecondaryClass", "N/A")
 
 		local MassLabel = Menu:AddLabel("")
+		local CostLabel = Menu:AddLabel("")
 		local AutoloaderSize = Vector(0, 0, 0)
 
 		local function UpdateAutoloaderStats()
@@ -26,6 +27,7 @@ Components.RegisterItem("AL-IMP", "AL", {
 			local Volume = math.pi * R * R * H
 
 			MassLabel:SetText(string.format("Mass : %s", ACF.GetProperMass(Volume * 250)))
+			CostLabel:SetText(string.format("Cost : %s", ACF.GetProperCost(Volume * 8)))
 
 			if Menu.ComponentPreview then
 				Menu.ComponentPreview:SetModelScale(AutoloaderSize, true)

--- a/lua/acf/menu/items_cl/crew_menu.lua
+++ b/lua/acf/menu/items_cl/crew_menu.lua
@@ -248,6 +248,7 @@ local function CreateMenu(Menu)
 	local Whitelist = Base:AddLabel()
 	local Pose = Base:AddLabel()
 	local Mass = Base:AddLabel()
+	local Cost = Base:AddLabel()
 	local Leans = Base:AddLabel()
 	local GEfficiencies = Base:AddLabel()
 	local GDamages = Base:AddLabel()
@@ -286,6 +287,7 @@ local function CreateMenu(Menu)
 		Whitelist:SetText(language.GetPhrase("acf.menu.crew.links_to"):format(table.concat(wl, ", ")))
 
 		Mass:SetText(language.GetPhrase("acf.menu.crew.mass_text"):format(Data.Mass))
+		Cost:SetText(language.GetPhrase("acf.menu.crew.cost_text"):format(ACF.GetProperCost(Data.Cost or 1)))
 
 		if not Data.LeanInfo then Leans:SetText("#acf.menu.crew.lean_no_info")
 		else

--- a/lua/acf/menu/items_cl/crew_menu.lua
+++ b/lua/acf/menu/items_cl/crew_menu.lua
@@ -287,7 +287,7 @@ local function CreateMenu(Menu)
 		Whitelist:SetText(language.GetPhrase("acf.menu.crew.links_to"):format(table.concat(wl, ", ")))
 
 		Mass:SetText(language.GetPhrase("acf.menu.crew.mass_text"):format(Data.Mass))
-		Cost:SetText(language.GetPhrase("acf.menu.crew.cost_text"):format(ACF.GetProperCost(Data.Cost or 1)))
+		Cost:SetText(language.GetPhrase("acf.menu.crew.cost_text"):format(ACF.FormatCost(Data.Cost or 1)))
 
 		if not Data.LeanInfo then Leans:SetText("#acf.menu.crew.lean_no_info")
 		else

--- a/lua/acf/menu/items_cl/engines.lua
+++ b/lua/acf/menu/items_cl/engines.lua
@@ -3,8 +3,6 @@ local Classes     = ACF.Classes
 local EngineTypes = Classes.EngineTypes
 local FuelTypes   = Classes.FuelTypes
 local Engines     = Classes.Engines
-local ModelData   = ACF.ModelData
-local ArmorTypes  = Classes.ArmorTypes
 local TankSize    = Vector()
 local HPColor     = Color(255, 65, 65)
 local TorqueColor = Color(65, 65, 255)
@@ -20,8 +18,8 @@ local function UpdateEngineStats(Label, Data)
 	local PeakkWRPM  = Data.PeakPowerRPM
 	local MinPower   = RPM.PeakMin
 	local MaxPower   = RPM.PeakMax
-	local Volume     = ModelData.GetModelVolume(Data.Model)
-	local Mass       = ACF.GetProperMass(Volume and math.Round(Volume * ACF.InchToMCu * ArmorTypes.Get("Component").Density) or 0)
+	local Mass       = ACF.GetProperMass(Data.Mass or 0)
+	local Cost       = ACF.GetProperCost(math.max(5, (Data.Torque / 160) + (Data.PeakPower / 80)))
 	local Torque     = math.Round(Data.Torque * GetTorqueMult())
 	local TorqueFeet = math.Round(Data.Torque * GetTorqueMult() * ACF.NmToFtLb)
 	local Type       = EngineTypes.Get(Data.Type)
@@ -54,7 +52,7 @@ local function UpdateEngineStats(Label, Data)
 
 	local Power = PowerText:format(Torque, TorqueFeet, PeakTqRPM, math.Round(PeakkW), math.Round(PeakkW * ACF.KwToHp), PeakkWRPM)
 
-	Label:SetText(RPMText:format(RPM.Idle, MinPower, MaxPower, RPM.Limit, Mass, FuelList, Power))
+	Label:SetText(RPMText:format(RPM.Idle, MinPower, MaxPower, RPM.Limit, Mass, Cost, FuelList, Power))
 end
 
 local function CreateMenu(Menu)

--- a/lua/acf/menu/items_cl/engines.lua
+++ b/lua/acf/menu/items_cl/engines.lua
@@ -19,7 +19,7 @@ local function UpdateEngineStats(Label, Data)
 	local MinPower   = RPM.PeakMin
 	local MaxPower   = RPM.PeakMax
 	local Mass       = ACF.FormatMass(Data.Mass or 0)
-	local Cost       = ACF.FormatCost(math.max(5, (Data.Torque / 160) + (Data.PeakPower / 80)))
+	local Cost       = ACF.FormatCost(math.max(5, (Data.Torque / 180) + (Data.PeakPower / 100)))
 	local Torque     = math.Round(Data.Torque * GetTorqueMult())
 	local TorqueFeet = math.Round(Data.Torque * GetTorqueMult() * ACF.NmToFtLb)
 	local Type       = EngineTypes.Get(Data.Type)

--- a/lua/acf/menu/items_cl/engines.lua
+++ b/lua/acf/menu/items_cl/engines.lua
@@ -18,8 +18,8 @@ local function UpdateEngineStats(Label, Data)
 	local PeakkWRPM  = Data.PeakPowerRPM
 	local MinPower   = RPM.PeakMin
 	local MaxPower   = RPM.PeakMax
-	local Mass       = ACF.GetProperMass(Data.Mass or 0)
-	local Cost       = ACF.GetProperCost(math.max(5, (Data.Torque / 160) + (Data.PeakPower / 80)))
+	local Mass       = ACF.FormatMass(Data.Mass or 0)
+	local Cost       = ACF.FormatCost(math.max(5, (Data.Torque / 160) + (Data.PeakPower / 80)))
 	local Torque     = math.Round(Data.Torque * GetTorqueMult())
 	local TorqueFeet = math.Round(Data.Torque * GetTorqueMult() * ACF.NmToFtLb)
 	local Type       = EngineTypes.Get(Data.Type)
@@ -276,7 +276,7 @@ local function CreateMenu(Menu)
 			local Liters = math.Round(Capacity, 2)
 			local Gallons = math.Round(Capacity * ACF.LToGal, 2)
 
-			FuelText = FuelText .. Text:format(Liters, Gallons, ACF.GetProperMass(Mass))
+			FuelText = FuelText .. Text:format(Liters, Gallons, ACF.FormatMass(Mass))
 		end
 
 		FuelDesc:SetText("Scalable Fuel Tank\n\nShape: " .. Shape)

--- a/lua/acf/menu/items_cl/fun_entities.lua
+++ b/lua/acf/menu/items_cl/fun_entities.lua
@@ -109,7 +109,7 @@ do -- Piledrivers menu
 			local MaxPen    = math.Round(BulletData.MaxPen, 2)
 			local MuzzleVel = math.Round(BulletData.MuzzleVel, 2)
 			local Length    = BulletData.ProjLength
-			local Mass      = ACF.GetProperMass(BulletData.ProjMass)
+			local Mass      = ACF.FormatMass(BulletData.ProjMass)
 
 			return Stats:format(MaxPen, MuzzleVel, Length, Mass)
 		end)

--- a/lua/acf/menu/items_cl/gearboxes.lua
+++ b/lua/acf/menu/items_cl/gearboxes.lua
@@ -6,7 +6,7 @@ local StatsText  = language.GetPhrase("acf.menu.gearboxes.stats")
 local function SetStatsText(GearboxStats)
 	local Mass, Torque, TorqueRating = ACF.GetGearboxStats(Current.Mass, Current.Scale, Current.MaxTorque, Current.GearCount)
 
-	GearboxStats:SetText(StatsText:format(ACF.GetProperMass(Mass), TorqueRating * ACF.TorqueMult, Torque * ACF.TorqueMult))
+	GearboxStats:SetText(StatsText:format(ACF.FormatMass(Mass), TorqueRating * ACF.TorqueMult, Torque * ACF.TorqueMult))
 end
 
 local CreateSubMenu

--- a/lua/acf/menu/items_cl/gearboxes.lua
+++ b/lua/acf/menu/items_cl/gearboxes.lua
@@ -1,14 +1,10 @@
 local ACF        = ACF
 local Gearboxes  = ACF.Classes.Gearboxes
-local ModelData  = ACF.ModelData
-local ArmorTypes = ACF.Classes.ArmorTypes
 local Current    = {}
 local StatsText  = language.GetPhrase("acf.menu.gearboxes.stats")
 
 local function SetStatsText(GearboxStats)
-	local _, Torque, TorqueRating = ACF.GetGearboxStats(Current.Mass, Current.Scale, Current.MaxTorque, Current.GearCount)
-	local Volume = Current.Model and ModelData.GetModelVolume(Current.Model, Current.Scale or 1)
-	local Mass   = Volume and math.Round(Volume * ACF.InchToMCu * ArmorTypes.Get("Component").Density) or 0
+	local Mass, Torque, TorqueRating = ACF.GetGearboxStats(Current.Mass, Current.Scale, Current.MaxTorque, Current.GearCount)
 
 	GearboxStats:SetText(StatsText:format(ACF.GetProperMass(Mass), TorqueRating * ACF.TorqueMult, Torque * ACF.TorqueMult))
 end

--- a/lua/acf/menu/items_cl/missiles.lua
+++ b/lua/acf/menu/items_cl/missiles.lua
@@ -36,7 +36,7 @@ local function GetMissileText(Data)
 		View = "\nView Cone : " .. Data.ViewCone * 2 .. " degrees"
 	end
 
-	return MissileText:format(Caliber, ACF.GetProperMass(Data.Mass or 10), Data.ArmDelay, Seek, View)
+	return MissileText:format(Caliber, ACF.FormatMass(Data.Mass or 10), Data.ArmDelay, Seek, View)
 end
 
 local function GetRackText(Data)
@@ -53,7 +53,7 @@ local function GetRackText(Data)
 
 	local Cost = Data.MagSize * 1.5 * math.max(1, math.max(70, Data.Caliber or 0) / 70) -- Mirrors acf_rack's GetCost
 
-	return RackText:format(Caliber, ACF.GetProperMass(Data.Mass or 0), ACF.GetProperCost(Cost), Data.MagSize, Protect)
+	return RackText:format(Caliber, ACF.FormatMass(Data.Mass or 0), ACF.FormatCost(Cost), Data.MagSize, Protect)
 end
 
 local function CreateMenu(Menu)

--- a/lua/acf/menu/items_cl/missiles.lua
+++ b/lua/acf/menu/items_cl/missiles.lua
@@ -2,8 +2,6 @@ local ACF        = ACF
 local Classes    = ACF.Classes
 local Missiles   = Classes.Missiles
 local Racks      = Classes.Racks
-local ModelData  = ACF.ModelData
-local ArmorTypes = Classes.ArmorTypes
 
 local function GetRackList(Data)
 	local Result = {}
@@ -21,15 +19,9 @@ local function GetRackList(Data)
 	return Result
 end
 
-local BaseText = "Caliber : %s\nMass : %s kg"
-local RackText = BaseText .. "\nMunitions : %s%s\n"
+local BaseText = "Caliber : %s\nMass : %s"
+local RackText = BaseText .. "\nCost : %s\nMunitions : %s%s\n"
 local MissileText = BaseText .. "\nArming Delay : %ss%s%s"
-
-local function GetVolumetricMass(Model)
-	local Volume = ModelData.GetModelVolume(Model)
-	if not Volume then return 0 end
-	return math.Round(Volume * ACF.InchToMCu * ArmorTypes.Get("Component").Density)
-end
 
 local function GetMissileText(Data)
 	local Caliber = Data.Caliber .. "mm"
@@ -44,7 +36,7 @@ local function GetMissileText(Data)
 		View = "\nView Cone : " .. Data.ViewCone * 2 .. " degrees"
 	end
 
-	return MissileText:format(Caliber, GetVolumetricMass(Data.Model), Data.ArmDelay, Seek, View)
+	return MissileText:format(Caliber, ACF.GetProperMass(Data.Mass or 10), Data.ArmDelay, Seek, View)
 end
 
 local function GetRackText(Data)
@@ -59,7 +51,9 @@ local function GetRackText(Data)
 		Protect = "\n\nThis rack will protect its payload from getting destroyed."
 	end
 
-	return RackText:format(Caliber, GetVolumetricMass(Data.Model), Data.MagSize, Protect)
+	local Cost = Data.MagSize * 1.5 * math.max(1, math.max(70, Data.Caliber or 0) / 70) -- Mirrors acf_rack's GetCost
+
+	return RackText:format(Caliber, ACF.GetProperMass(Data.Mass or 0), ACF.GetProperCost(Cost), Data.MagSize, Protect)
 end
 
 local function CreateMenu(Menu)

--- a/lua/acf/menu/items_cl/weapons.lua
+++ b/lua/acf/menu/items_cl/weapons.lua
@@ -265,8 +265,8 @@ local function CreateMenu(Menu)
 		local Caliber  = Current.Caliber
 		if not Caliber then return "" end
 
-		local Mass     = ACF.GetProperMass(GetMass(Caliber, Class, Weapon))
-		local Cost     = ACF.GetProperCost(GetCost(Caliber, Class))
+		local Mass     = ACF.FormatMass(GetMass(Caliber, Class, Weapon))
+		local Cost     = ACF.FormatCost(GetCost(Caliber, Class))
 		local FireDelay = GetReloadTime(Caliber, Class, Weapon)
 		local FireRate = 60 / FireDelay
 		local Spread   = ACF.GetWeaponValue("Spread", Caliber, Class, Weapon)

--- a/lua/acf/menu/items_cl/weapons.lua
+++ b/lua/acf/menu/items_cl/weapons.lua
@@ -1,7 +1,5 @@
 local ACF        = ACF
 local Weapons    = ACF.Classes.Weapons
-local ModelData  = ACF.ModelData
-local ArmorTypes = ACF.Classes.ArmorTypes
 local Current    = {}
 local CreateControl, IsScalable
 
@@ -166,28 +164,25 @@ local function GetMagazineText(Caliber, Class, Weapon)
 end
 
 ---Returns the expected mass of a weapon that would be created by a given entry object.
----For scalable weapons, this might be 0 at first if the model information hasn't been received from the server.
----The panel will be automatically updated once the information is received.
----@param Panel userdata The label panel in which the weapon information is being listed on.
+---Mirrors acf_gun's own GetMass so the menu matches the spawned entity.
 ---@param Caliber? number The caliber of the weapon in mm. Not necessary for non-scalable weapons.
 ---@param Class? table<string, any> The weapon group object to get information from. Not necessary for non-scalable weapons.
 ---@param Weapon table<string, any> The weapon item object to get informatio from, not necessary for scalable weapons.
 ---@return number Mass The expected mass.
-local function GetMass(_, Caliber, Class, Weapon)
-	local Density = ArmorTypes.Get("GunSteel").Density
+local function GetMass(Caliber, Class, Weapon)
+	if Weapon then return Weapon.Mass or 0 end
 
-	if Weapon then
-		local Volume = ModelData.GetModelVolume(Weapon.Model)
-		if not Volume then return 0 end
-		return math.Round(Volume * ACF.InchToMCu * Density)
-	end
+	local Factor = Caliber / Class.Caliber.Base
 
-	local Scale  = Caliber / Class.Caliber.Base * (Class.ScaleFactor or 1)
-	local Volume = ModelData.GetModelVolume(Class.Model, Scale)
+	return math.Round((Class.Mass or 0) * Factor ^ 3) -- 3d space so scaling has a cubing effect
+end
 
-	if not Volume then return 0 end
-
-	return math.Round(Volume * ACF.InchToMCu * Density)
+---Returns the point cost of a weapon, mirroring acf_gun's GetCost.
+---@param Caliber number The caliber of the weapon in mm.
+---@param Class table<string, any> The weapon group object the weapon belongs to.
+---@return number Cost The expected cost in points.
+local function GetCost(Caliber, Class)
+	return (Class.CostScalar or 1) * Caliber
 end
 
 local function CreateMenu(Menu)
@@ -270,13 +265,14 @@ local function CreateMenu(Menu)
 		local Caliber  = Current.Caliber
 		if not Caliber then return "" end
 
-		local Mass     = ACF.GetProperMass(GetMass(EntData, Caliber, Class, Weapon))
+		local Mass     = ACF.GetProperMass(GetMass(Caliber, Class, Weapon))
+		local Cost     = ACF.GetProperCost(GetCost(Caliber, Class))
 		local FireDelay = GetReloadTime(Caliber, Class, Weapon)
 		local FireRate = 60 / FireDelay
 		local Spread   = ACF.GetWeaponValue("Spread", Caliber, Class, Weapon)
 		local Magazine = GetMagazineText(Caliber, Class, Weapon)
 
-		return EntText:format(Mass, math.Round(FireRate), math.Round(FireDelay, 3), Spread, Magazine)
+		return EntText:format(Mass, Cost, math.Round(FireRate), math.Round(FireDelay, 3), Spread, Magazine)
 	end
 	EntData:DefineSetter(Update)
 	EntData:SetText("")

--- a/lua/entities/acf_computer/init.lua
+++ b/lua/entities/acf_computer/init.lua
@@ -139,6 +139,7 @@ do -- Spawn and update function
 
 		Entity.Name         = Computer.Name
 		Entity.ShortName    = Entity.Computer
+		Entity.BaseCost     = Computer.Cost
 		Entity.EntType      = Class.Name
 		Entity.ClassData    = Class
 		Entity.OnUpdate     = Computer.OnUpdate or Class.OnUpdate
@@ -292,6 +293,10 @@ function ENT:ACF_OnRepaired()
 	end
 end
 
+function ENT:GetCost()
+	return self.BaseCost or 0
+end
+
 function ENT:Enable()
 	if self.OnEnabled then
 		self:OnEnabled()
@@ -305,8 +310,12 @@ function ENT:Disable()
 end
 
 function ENT:ACF_UpdateOverlayState(State)
-	if self.OverlayTitle then
-		self:OverlayTitle(State)
+	local Title = self.ACF.Health <= 0 and "Destroyed" or self.OverlayTitle and self:OverlayTitle()
+
+	if Title == "Destroyed" then
+		State:AddError(Title)
+	elseif Title then
+		State:AddSuccess(Title)
 	else
 		State:AddSuccess("Idle")
 	end

--- a/lua/entities/acf_engine/init.lua
+++ b/lua/entities/acf_engine/init.lua
@@ -907,7 +907,7 @@ end
 function ENT:GetCost()
 	local selftbl = self:GetTable()
 
-	return math.max(5, (selftbl.PeakTorque / 160) + (selftbl.PeakPower / 80))
+	return math.max(5, (selftbl.PeakTorque / 180) + (selftbl.PeakPower / 100))
 end
 
 function ENT:OnRemove()

--- a/lua/entities/acf_groundloader/init.lua
+++ b/lua/entities/acf_groundloader/init.lua
@@ -252,6 +252,6 @@ function ENT:ACF_PostMenuSpawn()
 	self:SetAngles(self:GetAngles() + Angle(0, -90, 0))
 end
 
-function ENT:GetCost() return 15 end
+function ENT:GetCost() return ACF.GroundLoaderCost end
 
 Entities.Register()

--- a/lua/entities/acf_piledriver/modules/wiremod.lua
+++ b/lua/entities/acf_piledriver/modules/wiremod.lua
@@ -18,7 +18,7 @@ function ENT:ACF_UpdateOverlayState(State)
     local Bullet  = self.BulletData
     local Display = self.RoundData:GetDisplayData(Bullet)
     local MaxPen  = math.Round(Display.MaxPen, 2)
-    local Mass    = ACF.GetProperMass(Bullet.ProjMass)
+    local Mass    = ACF.FormatMass(Bullet.ProjMass)
     local MuzVel  = math.Round(Bullet.MuzzleVel, 2)
     local Length  = Bullet.ProjLength
 

--- a/lua/entities/acf_radar/init.lua
+++ b/lua/entities/acf_radar/init.lua
@@ -448,6 +448,7 @@ do -- Spawn and Update functions
 		Entity.ConeDegs     = Radar.ViewCone
 		Entity.Range        = Radar.Range
 		Entity.MinSizeAtRange = Radar.MinSizeAtRange
+		Entity.BaseCost     = Radar.Cost
 		Entity.SwitchDelay  = Radar.SwitchDelay
 		Entity.ThinkTicks   = Radar.ThinkTicks -- Number of ticks between scans
 		Entity.TickCounter  = Entity.TickCounter or 0
@@ -608,25 +609,12 @@ function ENT:ResumeIndependentScanning()
 	end
 end
 
--- Static base cost per radar item, independent of the current detection-type selection
-local BaseCost = {
-	SmallDIR   = 12.5,
-	MediumDIR  = 25,
-	LargeDIR   = 50,
-	SmallOMNI  = 20,
-	MediumOMNI = 40,
-	LargeOMNI  = 80,
-}
-
--- Discount applied when a radar can only detect one target type instead of both
-local SingleTypeDiscount = 5
-
 function ENT:GetCost()
 	local selftbl = self:GetTable()
-	local Cost = BaseCost[selftbl.ShortName] or 0
+	local Cost = selftbl.BaseCost or 0
 
 	if selftbl.DetectContraptions ~= selftbl.DetectMissiles then
-		Cost = Cost - SingleTypeDiscount
+		Cost = Cost - ACF.RadarSingleTypeDiscount
 	end
 
 	return Cost

--- a/lua/entities/acf_radarsync/init.lua
+++ b/lua/entities/acf_radarsync/init.lua
@@ -480,7 +480,7 @@ function ENT:ACF_OnDamage(DmgResult, DmgInfo)
 end
 
 function ENT:GetCost()
-	return 1
+	return ACF.RadarSyncCost
 end
 
 function ENT:Enable() end

--- a/lua/entities/acf_receiver/init.lua
+++ b/lua/entities/acf_receiver/init.lua
@@ -148,6 +148,7 @@ do -- Spawn and Update functions
 
 		Entity.Name         = Receiver.Name
 		Entity.ShortName    = Receiver.Name
+		Entity.BaseCost     = Receiver.Cost
 		Entity.EntType      = Class.Name
 		Entity.ClassType    = Class.ID
 		Entity.ClassData    = Class
@@ -267,6 +268,10 @@ end
 
 function ENT:ACF_OnRepaired() -- OldArmor, OldHealth, Armor, Health
 	self.Damage = 1 - math.Round(self.ACF.Health / self.ACF.MaxHealth, 2)
+end
+
+function ENT:GetCost()
+	return self.BaseCost or 0
 end
 
 function ENT:Enable()

--- a/lua/entities/acf_turret_controller/init.lua
+++ b/lua/entities/acf_turret_controller/init.lua
@@ -205,7 +205,7 @@ do	-- Metamethods
 		end
 
 		function ENT:GetCost()
-			return self.IsRemote and 100 or 5
+			return self.IsRemote and 70 or 5
 		end
 	end
 

--- a/resource/localization/de/acf_menu_crew.properties
+++ b/resource/localization/de/acf_menu_crew.properties
@@ -36,6 +36,7 @@ acf.menu.crew.replaced_only_lower=Nur höhrere Prioritäten können mich ersetze
 acf.menu.crew.max_per_contraption=Max. pro Konstruktion: %G
 acf.menu.crew.links_to=Verbindet mit: %s
 acf.menu.crew.mass_text=Masse: %G kg
+acf.menu.crew.cost_text=Kosten: %s
 acf.menu.crew.lean_stats=Beste Effizienz vor: %G° lean\nSchlechteste Effizienz nach: %G° lean
 acf.menu.crew.lean_no_info=Effizienz unabhängig vom Neigewinkel
 acf.menu.crew.gforce_stats=Beste Effizienz vor: %G G\nSchlechteste Effizienz nach: %G G

--- a/resource/localization/de/acf_menu_engines.properties
+++ b/resource/localization/de/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Motoreinstellungen
 
 # Engine Information category
 acf.menu.engines.engine_info=Motorinformationen
-acf.menu.engines.rpm_stats=Leerlaufdrehzahl : %s RPM\nLeistungsband : %s-%s RPM\nDrehzahlgrenze : %s RPM\nMasse : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=Leerlaufdrehzahl : %s RPM\nLeistungsband : %s-%s RPM\nDrehzahlgrenze : %s RPM\nMasse : %s\nKosten : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Max. Drehmoment : %s Nm - %s ft-lb @ %s RPM\nMax. Leistung : %s kW - %s PS @ %s RPM
 acf.menu.engines.consumption_stats=%s Verbrauch :\n%s L/min - %s gal/min @ %s RPM
 

--- a/resource/localization/de/acf_menu_turrets.properties
+++ b/resource/localization/de/acf_menu_turrets.properties
@@ -5,6 +5,7 @@ acf.menu.turrets.menu_desc=Typischerweise platzieren Sie zuerst den horizontalen
 acf.menu.turrets.components=Turmkoponenten
 acf.menu.turrets.turret_mass_text=Antriebsmasse: %s kg, %s kg max. Kapazität
 acf.menu.turrets.mass_text=Masse: %s kg
+acf.menu.turrets.cost_text=Kosten: %s
 acf.menu.turrets.estimated_mass=Geschätzte Masse (kg)
 acf.menu.turrets.mass_center_distance=Massenschwerpunkt-Abstand
 acf.menu.turrets.degrees_per_second=Grad/Sek

--- a/resource/localization/de/acf_menu_weapons.properties
+++ b/resource/localization/de/acf_menu_weapons.properties
@@ -5,7 +5,7 @@ acf.menu.weapons.settings=Waffeneinstellungen
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Waffeneinstellungen
 acf.menu.weapons.name_text=%smm %s
-acf.menu.weapons.weapon_stats=Masse: %s\nFeuerrate: %s Schuss/min\nFeuerverzögerung: %s s\nStreuung: %s Grad%s
+acf.menu.weapons.weapon_stats=Masse: %s\nKosten: %s\nFeuerrate: %s Schuss/min\nFeuerverzögerung: %s s\nStreuung: %s Grad%s
 acf.menu.weapons.mag_stats=\nMagazingröße: %s Schuss\nNachladezeit: %s Sekunden
 
 # Ammo Settings category
@@ -20,7 +20,7 @@ acf.menu.ammo.projectile_length=Projektilänge
 acf.menu.ammo.propellant_length=Treibsatzlänge
 acf.menu.ammo.tracer=Leuchtspur
 acf.menu.ammo.stage=Stufe
-acf.menu.ammo.crate_stats=Kistenmasse: %s\nKapazität: %s Schuss
+acf.menu.ammo.crate_stats=Kistenmasse: %s\nKistenkosten: %s\nKapazität: %s Schuss
 
 # Graph labels
 acf.menu.ammo.distance=Entfernung (m)

--- a/resource/localization/en-PT/acf_menu_engines.properties
+++ b/resource/localization/en-PT/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Engine Orders
 
 # Engine Information category
 acf.menu.engines.engine_info=Engine Knowledge
-acf.menu.engines.rpm_stats=Idle Speed : %s spins/min\nPower Range : %s-%s spins/min\nDanger Zone : %s spins/min\nWeight : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=Idle Speed : %s spins/min\nPower Range : %s-%s spins/min\nDanger Zone : %s spins/min\nWeight : %s\nPrice : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Max Torque : %s Nm - %s ft-lb @ %s spins/min\nMax Power : %s kW - %s horsepower @ %s spins/min
 acf.menu.engines.consumption_stats=%s Consumption :\n%s l/min - %s gal/min @ %s spins/min
 

--- a/resource/localization/en-PT/acf_menu_weapons.properties
+++ b/resource/localization/en-PT/acf_menu_weapons.properties
@@ -4,7 +4,7 @@ acf.menu.weapons.settings=Cannon Orders
 
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Cannon Settings
-acf.menu.weapons.weapon_stats=Weight : %s\nLength : %s\nRate o' Fire : %s shots/minute\nSpread : %s mrad\nShot Weight : %s\nSpeed : %s m/s\nMax Range : %s meters
+acf.menu.weapons.weapon_stats=Weight : %s\nPrice : %s\nRate o' Fire : %s shots/minute\nShot Delay : %s s\nSpread : %s degrees%s
 
 # Ammo Information category
 acf.menu.weapons.ammo_info=Shot Knowledge
@@ -33,3 +33,4 @@ acf.names.he=High Explosive (HE)
 acf.descs.he=Explodin' shot fer blastin' everything nearby
 acf.names.hp=Soft Shot (HP)
 acf.descs.hp=Soft shot fer damagin' unarmored targets
+acf.menu.ammo.crate_stats=Crate Weight : %s\nCrate Price : %s\nCrate Capacity : %s round(s)

--- a/resource/localization/en/acf_menu_crew.properties
+++ b/resource/localization/en/acf_menu_crew.properties
@@ -37,6 +37,7 @@ acf.menu.crew.replaced_only_lower=Only higher priorities can replace me
 acf.menu.crew.max_per_contraption=Max Per Contraption: %G
 acf.menu.crew.links_to=Links to: %s
 acf.menu.crew.mass_text=Mass: %G kg
+acf.menu.crew.cost_text=Cost: %s
 acf.menu.crew.lean_stats=Best efficiency before: %G° lean\nWorst efficiency after: %G° lean
 acf.menu.crew.lean_no_info=Efficiency unaffected by lean angle
 acf.menu.crew.gforce_stats=Best efficiency before: %G G\nWorst efficiency after: %G G

--- a/resource/localization/en/acf_menu_engines.properties
+++ b/resource/localization/en/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Engine Settings
 
 # Engine Information category
 acf.menu.engines.engine_info=Engine Information
-acf.menu.engines.rpm_stats=Idle RPM : %s RPM\nPowerband : %s-%s RPM\nRedline : %s RPM\nMass : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=Idle RPM : %s RPM\nPowerband : %s-%s RPM\nRedline : %s RPM\nMass : %s\nCost : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Peak Torque : %s Nm - %s ft-lb @ %s RPM\nPeak Power : %s kW - %s HP @ %s RPM
 acf.menu.engines.consumption_stats=%s Consumption :\n%s L/min - %s gal/min @ %s RPM
 

--- a/resource/localization/en/acf_menu_turrets.properties
+++ b/resource/localization/en/acf_menu_turrets.properties
@@ -5,6 +5,7 @@ acf.menu.turrets.menu_desc=Typically, place the horizontal turret, and then pare
 acf.menu.turrets.components=Turret Components
 acf.menu.turrets.turret_mass_text=Drive Mass : %s kg, %s kg max capacity
 acf.menu.turrets.mass_text=Mass : %s kg
+acf.menu.turrets.cost_text=Cost : %s
 acf.menu.turrets.estimated_mass=Estimated Mass (kg)
 acf.menu.turrets.mass_center_distance=Mass Center Dist.
 acf.menu.turrets.degrees_per_second=Degrees/Sec

--- a/resource/localization/en/acf_menu_weapons.properties
+++ b/resource/localization/en/acf_menu_weapons.properties
@@ -5,7 +5,7 @@ acf.menu.weapons.settings=Weapon Settings
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Weapon Settings
 acf.menu.weapons.name_text=%smm %s
-acf.menu.weapons.weapon_stats=Mass : %s\nFire Rate : %s rpm\nFire Delay : %s s\nSpread : %s degrees%s
+acf.menu.weapons.weapon_stats=Mass : %s\nCost : %s\nFire Rate : %s rpm\nFire Delay : %s s\nSpread : %s degrees%s
 acf.menu.weapons.mag_stats=\nRounds : %s rounds\nReload : %s seconds
 
 # Ammo Settings category
@@ -26,7 +26,7 @@ acf.menu.ammo.tracer=Tracer
 acf.menu.ammo.two_piece=Two Piece
 acf.menu.ammo.hex_packing=Hex Packing
 acf.menu.ammo.stage=Stage
-acf.menu.ammo.crate_stats=Crate Mass : %s\nCrate Capacity : %s round(s)
+acf.menu.ammo.crate_stats=Crate Mass : %s\nCrate Cost : %s\nCrate Capacity : %s round(s)
 
 # Graph labels
 acf.menu.ammo.distance=Distance (m)

--- a/resource/localization/es/acf_menu_engines.properties
+++ b/resource/localization/es/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Configuración del motor
 
 # Engine Information category
 acf.menu.engines.engine_info=Información del motor
-acf.menu.engines.rpm_stats=RPM en ralentí : %s rpm\nRango de potencia : %s-%s rpm\nZona roja : %s rpm\nPeso : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=RPM en ralentí : %s rpm\nRango de potencia : %s-%s rpm\nZona roja : %s rpm\nPeso : %s\nCoste : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Par máximo : %s Nm - %s ft-lb @ %s rpm\nPotencia máxima : %s kW - %s hp @ %s rpm
 acf.menu.engines.consumption_stats=Consumo de %s :\n%s l/min - %s gal/min @ %s rpm
 

--- a/resource/localization/es/acf_menu_weapons.properties
+++ b/resource/localization/es/acf_menu_weapons.properties
@@ -4,7 +4,7 @@ acf.menu.weapons.settings=Configuración de armas
 
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Configuración del arma
-acf.menu.weapons.weapon_stats=Peso : %s\nLongitud : %s\nCadencia de fuego : %s disparos/min\nDispersión : %s mrad\nPeso del proyectil : %s\nVelocidad : %s m/s\nAlcance máximo : %s m
+acf.menu.weapons.weapon_stats=Peso : %s\nCoste : %s\nCadencia de fuego : %s disparos/min\nRetardo de disparo : %s s\nDispersión : %s grados%s
 
 # Ammo Information category
 acf.menu.weapons.ammo_info=Información de munición
@@ -33,3 +33,4 @@ acf.names.he=Alto explosivo (HE)
 acf.descs.he=Proyectil explosivo para daño de área
 acf.names.hp=Plástico explosivo (HP)
 acf.descs.hp=Proyectil blando para dañar objetivos sin protección
+acf.menu.ammo.crate_stats=Masa de la caja : %s\nCoste de la caja : %s\nCapacidad de la caja : %s proyectil(es)

--- a/resource/localization/fr/acf_menu_engines.properties
+++ b/resource/localization/fr/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Paramètres du moteur
 
 # Engine Information category
 acf.menu.engines.engine_info=Informations sur le moteur
-acf.menu.engines.rpm_stats=Régime de ralenti : %s tr/min\nPlage de puissance : %s-%s tr/min\nZone rouge : %s tr/min\nPoids : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=Régime de ralenti : %s tr/min\nPlage de puissance : %s-%s tr/min\nZone rouge : %s tr/min\nPoids : %s\nCoût : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Couple maximal : %s Nm - %s ft-lb @ %s tr/min\nPuissance maximale : %s kW - %s ch @ %s tr/min
 acf.menu.engines.consumption_stats=Consommation de %s :\n%s l/min - %s gal/min @ %s tr/min
 

--- a/resource/localization/fr/acf_menu_weapons.properties
+++ b/resource/localization/fr/acf_menu_weapons.properties
@@ -4,7 +4,7 @@ acf.menu.weapons.settings=Paramètres des armes
 
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Paramètres de l'arme
-acf.menu.weapons.weapon_stats=Poids : %s\nLongueur : %s\nCadence de tir : %s coups/min\nDispersion : %s mrad\nPoids du projectile : %s\nVitesse : %s m/s\nPortée maximale : %s m
+acf.menu.weapons.weapon_stats=Poids : %s\nCoût : %s\nCadence de tir : %s coups/min\nDélai de tir : %s s\nDispersion : %s degrés%s
 
 # Ammo Information category
 acf.menu.weapons.ammo_info=Informations sur les munitions
@@ -33,3 +33,4 @@ acf.names.he=Explosif (HE)
 acf.descs.he=Projectile explosif pour dégâts de zone
 acf.names.hp=Plastique explosif (HP)
 acf.descs.hp=Projectile mou pour endommager les cibles non protégées
+acf.menu.ammo.crate_stats=Masse de la caisse : %s\nCoût de la caisse : %s\nCapacité de la caisse : %s obus

--- a/resource/localization/ru/acf_menu_crew.properties
+++ b/resource/localization/ru/acf_menu_crew.properties
@@ -37,6 +37,7 @@ acf.menu.crew.replaced_only_lower=Только более высокие при�
 acf.menu.crew.max_per_contraption=Макс. на конструкцию: %G
 acf.menu.crew.links_to=Связывается с: %s
 acf.menu.crew.mass_text=Масса: %G кг
+acf.menu.crew.cost_text=Стоимость: %s
 acf.menu.crew.lean_stats=Лучшая эффективность до: %G° наклона\nХудшая эффективность после: %G° наклона
 acf.menu.crew.lean_no_info=Эффективность не затрагивается углом наклона
 acf.menu.crew.gforce_stats=Лучшая эффективность до: %G G\nХудшая эффективность после: %G G

--- a/resource/localization/ru/acf_menu_engines.properties
+++ b/resource/localization/ru/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Настройки двигателя
 
 # Engine Information category
 acf.menu.engines.engine_info=Информация о двигателе
-acf.menu.engines.rpm_stats=Холостые обороты : %s об/мин\nДиапазон мощности : %s-%s об/мин\nКрасная зона : %s об/мин\nМасса : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=Холостые обороты : %s об/мин\nДиапазон мощности : %s-%s об/мин\nКрасная зона : %s об/мин\nМасса : %s\nСтоимость : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Пиковый крутящий момент : %s Нм - %s фт-фунт @ %s об/мин\nПиковая мощность : %s кВт - %s л.с. @ %s об/мин
 acf.menu.engines.consumption_stats=Расход %s :\n%s л/мин - %s гал/мин @ %s об/мин
 

--- a/resource/localization/ru/acf_menu_turrets.properties
+++ b/resource/localization/ru/acf_menu_turrets.properties
@@ -5,6 +5,7 @@ acf.menu.turrets.menu_desc=Обычно размещайте горизонта�
 acf.menu.turrets.components=Компоненты башни
 acf.menu.turrets.turret_mass_text=Масса привода : %s кг, %s кг макс. вместимость
 acf.menu.turrets.mass_text=Масса : %s кг
+acf.menu.turrets.cost_text=Стоимость : %s
 acf.menu.turrets.estimated_mass=Расчетная масса (кг)
 acf.menu.turrets.mass_center_distance=Расстояние центра массы
 acf.menu.turrets.degrees_per_second=Градусы/сек

--- a/resource/localization/ru/acf_menu_weapons.properties
+++ b/resource/localization/ru/acf_menu_weapons.properties
@@ -5,7 +5,7 @@ acf.menu.weapons.settings=Настройки оружия
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Настройки оружия
 acf.menu.weapons.name_text=%sмм %s
-acf.menu.weapons.weapon_stats=Масса : %s\nСкорострельность : %s выстр/мин\nЗадержка выстрела : %s с\nРазброс : %s градусов%s
+acf.menu.weapons.weapon_stats=Масса : %s\nСтоимость : %s\nСкорострельность : %s выстр/мин\nЗадержка выстрела : %s с\nРазброс : %s градусов%s
 acf.menu.weapons.mag_stats=\nПатроны : %s патронов\nПерезарядка : %s секунд
 
 # Ammo Settings category
@@ -20,7 +20,7 @@ acf.menu.ammo.projectile_length=Длина снаряда
 acf.menu.ammo.propellant_length=Длина пороха
 acf.menu.ammo.tracer=Трассер
 acf.menu.ammo.stage=Стадия
-acf.menu.ammo.crate_stats=Масса ящика : %s\nВместимость ящика : %s снаряд(ов)
+acf.menu.ammo.crate_stats=Масса ящика : %s\nСтоимость ящика : %s\nВместимость ящика : %s снаряд(ов)
 
 # Graph labels
 acf.menu.ammo.distance=Расстояние (м)

--- a/resource/localization/uk/acf_menu_engines.properties
+++ b/resource/localization/uk/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=Налаштування двигуна
 
 # Engine Information category
 acf.menu.engines.engine_info=Інформація про двигун
-acf.menu.engines.rpm_stats=Холості оберти : %s об/хв\nДіапазон потужності : %s-%s об/хв\nЧервона зона : %s об/хв\nМаса : %s\n\n%s\n%s
+acf.menu.engines.rpm_stats=Холості оберти : %s об/хв\nДіапазон потужності : %s-%s об/хв\nЧервона зона : %s об/хв\nМаса : %s\nВартість : %s\n\n%s\n%s
 acf.menu.engines.power_stats=Піковий крутний момент : %s Нм - %s фт-фунт @ %s об/хв\nПікова потужність : %s кВт - %s к.с. @ %s об/хв
 acf.menu.engines.consumption_stats=Споживання %s :\n%s л/хв - %s гал/хв @ %s об/хв
 

--- a/resource/localization/uk/acf_menu_weapons.properties
+++ b/resource/localization/uk/acf_menu_weapons.properties
@@ -4,7 +4,7 @@ acf.menu.weapons.settings=Налаштування зброї
 
 # Weapon Settings category
 acf.menu.weapons.weapon_info=Налаштування зброї
-acf.menu.weapons.weapon_stats=Маса : %s\nДовжина : %s\nШвидкострільність : %s пострілів/хв\nПоширення : %s мрад\nМаса снаряда : %s\nШвидкість : %s м/с\nМаксимальна дальність : %s м
+acf.menu.weapons.weapon_stats=Маса : %s\nВартість : %s\nШвидкострільність : %s пострілів/хв\nЗатримка пострілу : %s с\nПоширення : %s градусів%s
 
 # Ammo Information category
 acf.menu.weapons.ammo_info=Інформація про боєприпаси
@@ -33,3 +33,4 @@ acf.names.he=Фугасний (HE)
 acf.descs.he=Вибуховий снаряд для пошкодження площі
 acf.names.hp=Фугасно-пластиковий (HP)
 acf.descs.hp=М'який снаряд для пошкодження незахищених цілей
+acf.menu.ammo.crate_stats=Маса ящика : %s\nВартість ящика : %s\nМісткість ящика : %s снаряд(ів)

--- a/resource/localization/zh-CN/acf_menu_engines.properties
+++ b/resource/localization/zh-CN/acf_menu_engines.properties
@@ -4,7 +4,7 @@ acf.menu.engines.settings=引擎设置
 
 # Engine Information category
 acf.menu.engines.engine_info=引擎信息
-acf.menu.engines.rpm_stats=怠速转速：%s 转/分\n功率范围：%s-%s 转/分\n红线转速：%s 转/分\n重量：%s\n\n%s\n%s
+acf.menu.engines.rpm_stats=怠速转速：%s 转/分\n功率范围：%s-%s 转/分\n红线转速：%s 转/分\n重量：%s\n成本：%s\n\n%s\n%s
 acf.menu.engines.power_stats=峰值扭矩：%s 牛米 - %s 英尺磅 @ %s 转/分\n峰值功率：%s 千瓦 - %s 马力 @ %s 转/分
 acf.menu.engines.consumption_stats=%s 消耗：\n%s 升/分 - %s 加仑/分 @ %s 转/分
 

--- a/resource/localization/zh-CN/acf_menu_weapons.properties
+++ b/resource/localization/zh-CN/acf_menu_weapons.properties
@@ -4,7 +4,7 @@ acf.menu.weapons.settings=武器设置
 
 # Weapon Settings category
 acf.menu.weapons.weapon_info=武器设置
-acf.menu.weapons.weapon_stats=重量：%s\n长度：%s\n射速：%s 发/分\n散布：%s 毫弧度\n弹丸重量：%s\n速度：%s 米/秒\n最大射程：%s 米
+acf.menu.weapons.weapon_stats=重量：%s\n成本：%s\n射速：%s 发/分\n射击延迟：%s 秒\n散布：%s 度%s
 
 # Ammo Information category
 acf.menu.weapons.ammo_info=弹药信息
@@ -33,3 +33,4 @@ acf.names.he=高爆弹(HE)
 acf.descs.he=用于面杀伤的爆炸弹丸
 acf.names.hp=高爆塑料弹(HP)
 acf.descs.hp=用于杀伤无防护目标的软弹丸
+acf.menu.ammo.crate_stats=弹箱重量：%s\n弹箱成本：%s\n弹箱容量：%s 发


### PR DESCRIPTION
I think something happened on Github side, previous PR says it merged but that never happened. Original description for previous PR:

- All mass listings of components in the menu should now be accurate to the mass of the component when spawned

- Adds a cost listing for components which should be accurate to the cost of a component when spawned

New PR:
Cost changes
- Remote Turret Controller | 100 pts > 70 pts

- Guidance computers now have cost
Joysticks- 1 pt
GPS- 2 pts
Optical- 2 pts
Laser- 4 pts

- Warning receivers now have cost
LWR- 1.5 pts
RWR- 4 pts

- Changed weapon cost scalars
GRENADE LAUNCHER
OLD 0.5
NEW 0.38

HOWITZER
OLD 0.5
NEW 0.32

LIGHT AUTOCANNON
OLD 0.5
NEW 0.6

MACHINEGUN
OLD 0.25
NEW 0.4

MORTAR
OLD 0.35
NEW 0.29

SHORT CANNON
OLD 0.275
NEW 0.26

- Slightly decreased engine cost

Misc changes
- LAC now has access to APDS
- Lasers no longer overheat
- Small fix for laser / optical computers output when destroyed