### PR TITLE
Make semiautos evil

### DIFF
--- a/lua/acf/entities/ammo_types/heatfs.lua
+++ b/lua/acf/entities/ammo_types/heatfs.lua
@@ -15,7 +15,8 @@ function Ammo:OnLoaded()
 		M = true,
 		AL = true,
 		HW = true,
-		SC = true
+		SC = true,
+		SA = true
 	})
 
 	self.MaxStandoffRatio = 0.75

--- a/lua/acf/entities/weapons/semiauto.lua
+++ b/lua/acf/entities/weapons/semiauto.lua
@@ -26,7 +26,7 @@ Weapons.Register("SA", {
 	Caliber	= {
 		Base = 45,
 		Min  = 20,
-		Max  = 76,
+		Max  = 90,
 	},
 	MagReload = {
 		Min = 3,
@@ -34,7 +34,7 @@ Weapons.Register("SA", {
 	},
 	Cyclic = {
 		Min = 240,
-		Max = 100,
+		Max = 65,
 	},
 	BreechConfigs = {
 		MeasuredCaliber = 7.6,


### PR DESCRIPTION
- Increase semiauto max caliber to 90mm (sponsored by ARES Inc.)

- Give semiautos access to HEATFS