### PR TITLE
Resolve turret aim stabilization, take 2

### DIFF
--- a/lua/acf/entities/turrets/turrets.lua
+++ b/lua/acf/entities/turrets/turrets.lua
@@ -18,22 +18,7 @@ local CachedTurretAngle  = Angle(0, 0, 0)
 
 -- Bunched all of the definitions together due to some loading issue
 
-local math_min = math.min
-local math_max = math.max
-
 do	-- Turret drives
-	local function ClampAngleInPlace(A, minp, miny, minr, maxp, maxy, maxr)
-		local p, y, r = ANGLE.Unpack(A)
-
-		p = math_min(math_max(p, minp), maxp)
-		y = math_min(math_max(y, miny), maxy)
-		r = math_min(math_max(r, minr), maxr)
-
-		ANGLE.SetUnpacked(A, p, y, r)
-
-		return A
-	end
-
 	local WillUseSmallModel = function(Size) return Size <= 12.5 end
 	Turrets.WillUseSmallModel = WillUseSmallModel
 
@@ -197,16 +182,23 @@ do	-- Turret drives
 			end,
 
 			SlewFuncs		= {
+				-- Yaw the mount rotated since last tick, in the Turret's current frame, scaled by
+				-- StabilizeAmount. RunTurretSlew adds this as an acceleration-free feedforward term
+				-- to cancel mount motion; GetTargetBearing solves the aim target fresh.
 				GetStab				= function(Turret)
 					local TurretTbl = ENTITY.GetTable(Turret)
 
 					if (not (TurretTbl.Stabilized and TurretTbl.Active)) or (TurretTbl.Manual == true) then return 0 end
-					local AngDiff	= ENTITY.WorldToLocalAngles(TurretTbl.Rotator, TurretTbl.LastRotatorAngle)
-					local _, Yaw    = ANGLE.Unpack(AngDiff)
+
+					local _, Yaw = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Turret, TurretTbl.LastTurretAngle))
+
 					return (Yaw * TurretTbl.StabilizeAmount) or 0
 				end,
 
-				GetTargetBearing	= function(Turret, StabAmt)
+				-- Solves fresh each tick for the local yaw that points the Rotator at DesiredAngle,
+				-- given the Turret's current orientation, then expresses that as a gap relative to
+				-- the Rotator's actual transform. The fresh solve already accounts for mount drift.
+				GetTargetBearing	= function(Turret)
 					local TurretTbl = ENTITY.GetTable(Turret)
 					local Rotator = TurretTbl.Rotator
 
@@ -216,29 +208,26 @@ do	-- Turret drives
 							local _, Yaw = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, CachedTurretAngle)))
 							return Yaw
 						else
-							local AngDiff = ENTITY.WorldToLocalAngles(Rotator, TurretTbl.LastRotatorAngle)
 							local LocalDesiredAngle = ENTITY.WorldToLocalAngles(Turret, TurretTbl.DesiredAngle)
-							local ADPitch, ADYaw, ADRoll = ANGLE.Unpack(AngDiff)
-							ANGLE.SetUnpacked(CachedTurretAngle, -ADPitch, StabAmt - ADYaw, -ADRoll)
-							ANGLE.Sub(LocalDesiredAngle, CachedTurretAngle)
-							LocalDesiredAngle = ClampAngleInPlace(LocalDesiredAngle, 0, -TurretTbl.MaxDeg, 0, 0, -TurretTbl.MinDeg, 0)
+							local _, DesiredYaw = ANGLE.Unpack(LocalDesiredAngle)
+							ANGLE.SetUnpacked(CachedTurretAngle, 0, math.Clamp(DesiredYaw, -TurretTbl.MaxDeg, -TurretTbl.MinDeg), 0)
 
-							local _, Yaw = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, LocalDesiredAngle)))
+							local _, Yaw = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, CachedTurretAngle)))
 							return Yaw
 						end
 					else
-						local AngDiff = ENTITY.WorldToLocalAngles(Rotator, TurretTbl.LastRotatorAngle)
-						local AngleRet
 						if TurretTbl.Manual then
-							AngleRet = ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, Angle(0, -TurretTbl.DesiredDeg, 0)))
+							local AngleRet = ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, Angle(0, -TurretTbl.DesiredDeg, 0)))
 							local _, Yaw = ANGLE.Unpack(AngleRet)
 							return Yaw
 						else
-							ANGLE.SetUnpacked(CachedTurretAngle, ANGLE.Unpack(TurretTbl.DesiredAngle))
-							ANGLE.Add(CachedTurretAngle, AngDiff)
-							AngleRet = ENTITY.WorldToLocalAngles(Rotator, CachedTurretAngle)
+							local LocalDesiredAngle = ENTITY.WorldToLocalAngles(Turret, TurretTbl.DesiredAngle)
+							local _, DesiredYaw = ANGLE.Unpack(LocalDesiredAngle)
+							ANGLE.SetUnpacked(CachedTurretAngle, 0, DesiredYaw, 0)
+
+							local AngleRet = ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, CachedTurretAngle))
 							local _, Yaw = ANGLE.Unpack(AngleRet)
-							Yaw = Yaw - StabAmt
+
 							return Yaw
 						end
 					end
@@ -302,16 +291,22 @@ do	-- Turret drives
 			end,
 
 			SlewFuncs		= {
+				-- Pitch the mount rotated since last tick, in the Turret's current frame, scaled by
+				-- StabilizeAmount. Fed to RunTurretSlew as an acceleration-free feedforward term;
+				-- GetTargetBearing solves the aim target fresh.
 				GetStab				= function(Turret)
 					local TurretTbl = ENTITY.GetTable(Turret)
 
 					if (not (TurretTbl.Stabilized and TurretTbl.Active)) or (TurretTbl.Manual == true) then return 0 end
-					local AngDiff	= ENTITY.WorldToLocalAngles(TurretTbl.Rotator, TurretTbl.LastRotatorAngle)
-					local Pitch     = ANGLE.Unpack(AngDiff)
+
+					local Pitch = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Turret, TurretTbl.LastTurretAngle))
+
 					return (Pitch * TurretTbl.StabilizeAmount) or 0
 				end,
 
-				GetTargetBearing	= function(Turret, StabAmt)
+				-- Solves fresh each tick for the local pitch that points the Rotator at DesiredAngle,
+				-- given the Turret's current orientation. The fresh solve already accounts for mount drift.
+				GetTargetBearing	= function(Turret)
 					local TurretTbl = ENTITY.GetTable(Turret)
 					local Rotator = TurretTbl.Rotator
 
@@ -322,11 +317,10 @@ do	-- Turret drives
 							return Pitch
 						else
 							local LocalDesiredAngle = ENTITY.WorldToLocalAngles(Turret, TurretTbl.DesiredAngle)
-							ANGLE.SetUnpacked(CachedTurretAngle, StabAmt, 0, 0)
-							ANGLE.Sub(LocalDesiredAngle, CachedTurretAngle)
-							local LocalDesiredAngle = ClampAngleInPlace(LocalDesiredAngle, -TurretTbl.MaxDeg, 0, 0, -TurretTbl.MinDeg, 0, 0)
+							local DesiredPitch = ANGLE.Unpack(LocalDesiredAngle)
+							ANGLE.SetUnpacked(CachedTurretAngle, math.Clamp(DesiredPitch, -TurretTbl.MaxDeg, -TurretTbl.MinDeg), 0, 0)
 
-							local Pitch = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, LocalDesiredAngle)))
+							local Pitch = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, CachedTurretAngle)))
 							return Pitch
 						end
 					elseif TurretTbl.Manual then
@@ -334,8 +328,12 @@ do	-- Turret drives
 						local Pitch = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, CachedTurretAngle)))
 						return Pitch
 					else
-						local Pitch = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, TurretTbl.DesiredAngle))
-						return Pitch - StabAmt
+						local LocalDesiredAngle = ENTITY.WorldToLocalAngles(Turret, TurretTbl.DesiredAngle)
+						local DesiredPitch = ANGLE.Unpack(LocalDesiredAngle)
+						ANGLE.SetUnpacked(CachedTurretAngle, DesiredPitch, 0, 0)
+
+						local Pitch = ANGLE.Unpack(ENTITY.WorldToLocalAngles(Rotator, ENTITY.LocalToWorldAngles(Turret, CachedTurretAngle)))
+						return Pitch
 					end
 				end,
 

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -104,9 +104,63 @@ do -- Random timer crew stuff
 	end
 end
 
--- Every currently-spawned acf_turret, driven each tick by the shared ACF_OnTick hook below so
--- ancestors always update before their sub-turrets
+-- Every currently-spawned acf_turret, driven each tick by the shared ACF_OnTick hook below.
+-- RunOrder is the ancestor-first sequence that hook walks; an AugmentedTimer rebuilds and
+-- re-sorts it a few times a second so ancestors always slew before their sub-turrets, while
+-- spawn appends immediately so a new turret slews from its first tick.
 local ActiveTurrets = {}
+local RunOrder = {}
+local RunCount = 0
+
+-- Depth in the turret ancestor chain (0 = root), used to sort turrets ancestor-first
+local function GetAncestorDepth(SelfTbl)
+	local Depth = 0
+	local Ancestor = SelfTbl.ACF_TurretAncestor
+
+	while IsValid(Ancestor) do
+		Depth = Depth + 1
+		Ancestor = ENTITY.GetTable(Ancestor).ACF_TurretAncestor
+	end
+
+	return Depth
+end
+
+local function CompareTurretDepth(A, B)
+	return ENTITY.GetTable(A).SortDepth < ENTITY.GetTable(B).SortDepth
+end
+
+-- Rebuilds RunOrder from ActiveTurrets, ancestor-first. Comparing against a cached SortDepth
+-- keeps table.sort off the ancestor-chain walk. Driven by an AugmentedTimer rather than the
+-- tick hook so the sort cost is spread over frames.
+local function RebuildTurretRunOrder()
+	RunCount = 0
+
+	for Entity in pairs(ActiveTurrets) do
+		if IsValid(Entity) then
+			RunCount = RunCount + 1
+			RunOrder[RunCount] = Entity
+			ENTITY.GetTable(Entity).SortDepth = GetAncestorDepth(ENTITY.GetTable(Entity))
+		else
+			ActiveTurrets[Entity] = nil
+		end
+	end
+
+	for i = RunCount + 1, #RunOrder do
+		RunOrder[i] = nil
+	end
+
+	table.sort(RunOrder, CompareTurretDepth)
+end
+
+-- Appends a just-spawned turret so it slews from its first tick; the timer re-sorts it into
+-- ancestor-first position on its next pass.
+local function AppendTurretRunOrder(Entity)
+	if not IsValid(Entity) then return end
+
+	RunCount = RunCount + 1
+	RunOrder[RunCount] = Entity
+	ENTITY.GetTable(Entity).SortDepth = GetAncestorDepth(ENTITY.GetTable(Entity))
+end
 
 -- Some locals for entity functions that are stored as locals to avoid expensive
 -- __index operations in think hooks. They are still available for convenience.
@@ -417,6 +471,7 @@ do	-- Spawn and Update funcs
 		Entity:UpdateOverlay(true)
 
 		ActiveTurrets[Entity] = true
+		AppendTurretRunOrder(Entity)
 
 		ACF.AugmentedTimer(function(cfg) Entity:UpdateControlled(cfg) end, function() return IsValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1})
 
@@ -1236,44 +1291,21 @@ do -- Metamethods
 			SelfTbl.LastThinkTime	= Clock.CurTime
 		end
 
-		-- Depth in the turret ancestor chain (0 = root), used to sort turrets ancestor-first
-		local function GetAncestorDepth(SelfTbl)
-			local Depth = 0
-			local Ancestor = SelfTbl.ACF_TurretAncestor
-
-			while IsValid(Ancestor) do
-				Depth = Depth + 1
-				Ancestor = ENTITY.GetTable(Ancestor).ACF_TurretAncestor
-			end
-
-			return Depth
-		end
-
-		local SortBuffer = {}
+		ACF.AugmentedTimer(
+			function() RebuildTurretRunOrder() end,
+			function() return true end,
+			nil,
+			{MinTime = 1, MaxTime = 2}
+		)
 
 		hook.Add("ACF_OnTick", "ACF Turret Slew", function()
-			local Count = 0
+			for i = 1, RunCount do
+				local Entity = RunOrder[i]
 
-			for Entity in pairs(ActiveTurrets) do
+				-- Removed turrets linger until the next RebuildTurretRunOrder; skip them meanwhile
 				if IsValid(Entity) then
-					Count = Count + 1
-					SortBuffer[Count] = Entity
-				else
-					ActiveTurrets[Entity] = nil
+					RunTurretSlew(Entity, ENTITY.GetTable(Entity))
 				end
-			end
-
-			for i = Count + 1, #SortBuffer do
-				SortBuffer[i] = nil
-			end
-
-			table.sort(SortBuffer, function(A, B)
-				return GetAncestorDepth(ENTITY.GetTable(A)) < GetAncestorDepth(ENTITY.GetTable(B))
-			end)
-
-			for i = 1, Count do
-				local Entity = SortBuffer[i]
-				RunTurretSlew(Entity, ENTITY.GetTable(Entity))
 			end
 		end)
 	end

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -104,6 +104,10 @@ do -- Random timer crew stuff
 	end
 end
 
+-- Every currently-spawned acf_turret, driven each tick by the shared ACF_OnTick hook below so
+-- ancestors always update before their sub-turrets
+local ActiveTurrets = {}
+
 -- Some locals for entity functions that are stored as locals to avoid expensive
 -- __index operations in think hooks. They are still available for convenience.
 local ENT_CheckCoM
@@ -250,7 +254,8 @@ do	-- Spawn and Update funcs
 		Entity.SlewRate			= 0 -- Rotation rate
 		Entity.Stabilized		= false
 		Entity.StabilizeAmount	= 0
-		Entity.LastRotatorAngle	= Entity.Rotator:GetAngles()
+		Entity.LastTurretAngle	= Entity:GetAngles()
+		Entity.LastThinkTime	= Clock.CurTime
 
 		Entity.MaxSlewRate		= 0
 		Entity.SlewAccel		= 0
@@ -410,6 +415,8 @@ do	-- Spawn and Update funcs
 		UpdateTurret(Entity, Data, Class, Turret)
 
 		Entity:UpdateOverlay(true)
+
+		ActiveTurrets[Entity] = true
 
 		ACF.AugmentedTimer(function(cfg) Entity:UpdateControlled(cfg) end, function() return IsValid(Entity) end, nil, {MinTime = 0.5, MaxTime = 1})
 
@@ -1114,9 +1121,9 @@ do -- Metamethods
 			ApplyDirection(SelfTbl, Direction)
 		end
 
-		function ENT:Think() -- The meat and POE-TAE-TOES of the turret working
-			local SelfTbl = ENTITY.GetTable(self)
-
+		-- The meat and POE-TAE-TOES of the turret working. Called by the ACF_OnTick coordinator below,
+		-- ancestors first, instead of via ENT:Think()/NextThink
+		local function RunTurretSlew(self, SelfTbl)
 			-- Apply a deferred mid-cooldown change once the cooldown lapses
 			if SelfTbl.PendingDirection ~= nil and Clock.CurTime >= SelfTbl.LastAimInputTime + ACF.UncontrolledAimUpdateInterval then
 				SelfTbl.LastAimInputTime = Clock.CurTime
@@ -1127,13 +1134,15 @@ do -- Metamethods
 
 			if SelfTbl.Disabled then
 				SetSoundState(self, false, SelfTbl)
-				ENTITY.NextThink(self, Clock.CurTime + 0.1)
+				SelfTbl.LastTurretAngle = ENTITY.GetAngles(self)
+				SelfTbl.LastThinkTime	= Clock.CurTime
 
-				return true
+				return
 			end
 
 			ENT_CheckCoM(self, false, SelfTbl)
-			local Tick		= Clock.DeltaTime
+			-- Real elapsed time since last update, not assumed to be one tick
+			local Tick		= math_max(Clock.CurTime - (SelfTbl.LastThinkTime or Clock.CurTime), 0)
 			local Rotator	= SelfTbl.Rotator
 			if not IsValid(Rotator) then ENTITY.Remove(self) return end
 
@@ -1147,14 +1156,14 @@ do -- Metamethods
 
 			-- Something or another has caused the turret to be unable to rotate, so don't waste the extra processing time
 			if MaxImpulse == 0 then
-				SelfTbl.LastRotatorAngle = ENTITY.GetAngles(Rotator)
+				SelfTbl.LastTurretAngle = ENTITY.GetAngles(self)
+				SelfTbl.LastThinkTime	= Clock.CurTime
 
 				if SelfTbl.SoundPlaying == true then
 					SetSoundState(self, false, SelfTbl)
 				end
 
-				ENTITY.NextThink(self, Clock.CurTime + 0.1)
-				return true
+				return
 			end
 
 			if SelfTbl.UseVector and SelfTbl.Manual == false then
@@ -1163,19 +1172,20 @@ do -- Metamethods
 				SelfTbl.DesiredAngle = VECTOR.Angle(DesiredAngle)
 			end
 
-			local StabAmt	= math_Clamp(SelfTbl.SlewFuncs.GetStab(self), -SlewMax, SlewMax)
-			local StabSign	= -StabAmt < 0 and -1 or 1
+			-- Acceleration-free correction that cancels motion of whatever the turret is mounted to,
+			-- so a stabilized turret holds aim on a turning platform. Only the sum with SlewRate is
+			-- bounded (below); the motor's SlewAccel governs slewing toward the aim point, not this.
+			local FeedFwd	= SelfTbl.SlewFuncs.GetStab(self)
 
-			local TargetBearing	= math_Round(SelfTbl.SlewFuncs.GetTargetBearing(self, StabAmt), 8)
+			-- GetTargetBearing solves fresh against live orientation, so it already includes the
+			-- mount drift FeedFwd handles. Subtract it back out so the accel-limited feedback path
+			-- only chases operator-commanded error and the two don't double-correct.
+			local TargetBearing	= math_Round(SelfTbl.SlewFuncs.GetTargetBearing(self) - FeedFwd, 8)
 
 			local Sign			= TargetBearing < 0 and -1 or 1
 			local Dist			= math_abs(TargetBearing)
 			local FinalAccel	= math_Clamp(TargetBearing, -MaxImpulse, MaxImpulse)
 			local BrakingDist	= SelfTbl.SlewRate ^ 2 / math_abs(FinalAccel) / 2
-
-			if StabSign == Sign then
-				StabAmt = StabAmt * math_min(math_max(0, 1 - (math_abs(StabAmt) / MaxImpulse) ^ 2), 1)
-			end
 
 			if SelfTbl.Active then
 				SelfTbl.SlewRate = math_Clamp(SelfTbl.SlewRate + (math_abs(FinalAccel) * ((Dist + (SelfTbl.SlewRate * 2 * -Sign)) >= BrakingDist and Sign or -Sign)), -SlewMax, SlewMax)
@@ -1188,7 +1198,9 @@ do -- Metamethods
 				SelfTbl.SlewRate = SelfTbl.SlewRate - (math_min(SlewAccel, math_abs(SelfTbl.SlewRate)) * (SelfTbl.SlewRate >= 0 and 1 or -1))
 			end
 
-			SelfTbl.CurrentAngle = SelfTbl.CurrentAngle + math_Clamp(SelfTbl.SlewRate + StabAmt, -SlewMax, SlewMax)
+			-- Feedforward has acceleration headroom above a normal slew, but a violent enough
+			-- platform spin still leaves residual aim drift
+			SelfTbl.CurrentAngle = SelfTbl.CurrentAngle + math_Clamp(SelfTbl.SlewRate + FeedFwd, -SlewMax * 2, SlewMax * 2)
 
 			if SelfTbl.HasArc then
 				SelfTbl.CurrentAngle = math_Clamp(SelfTbl.CurrentAngle, -SelfTbl.MaxDeg, -SelfTbl.MinDeg)
@@ -1220,12 +1232,50 @@ do -- Metamethods
 				end
 			end
 
-			SelfTbl.LastRotatorAngle	= Rotator:GetAngles()
-
-			ENTITY.NextThink(self, Clock.CurTime)
-
-			return true
+			SelfTbl.LastTurretAngle	= self:GetAngles()
+			SelfTbl.LastThinkTime	= Clock.CurTime
 		end
+
+		-- Depth in the turret ancestor chain (0 = root), used to sort turrets ancestor-first
+		local function GetAncestorDepth(SelfTbl)
+			local Depth = 0
+			local Ancestor = SelfTbl.ACF_TurretAncestor
+
+			while IsValid(Ancestor) do
+				Depth = Depth + 1
+				Ancestor = ENTITY.GetTable(Ancestor).ACF_TurretAncestor
+			end
+
+			return Depth
+		end
+
+		local SortBuffer = {}
+
+		hook.Add("ACF_OnTick", "ACF Turret Slew", function()
+			local Count = 0
+
+			for Entity in pairs(ActiveTurrets) do
+				if IsValid(Entity) then
+					Count = Count + 1
+					SortBuffer[Count] = Entity
+				else
+					ActiveTurrets[Entity] = nil
+				end
+			end
+
+			for i = Count + 1, #SortBuffer do
+				SortBuffer[i] = nil
+			end
+
+			table.sort(SortBuffer, function(A, B)
+				return GetAncestorDepth(ENTITY.GetTable(A)) < GetAncestorDepth(ENTITY.GetTable(B))
+			end)
+
+			for i = 1, Count do
+				local Entity = SortBuffer[i]
+				RunTurretSlew(Entity, ENTITY.GetTable(Entity))
+			end
+		end)
 	end
 
 	do	-- Input/Outputs/Eventually linking
@@ -1371,6 +1421,8 @@ do -- Metamethods
 		function ENT:OnRemove()
 			local SelfTbl   = ENTITY.GetTable(self)
 			-- TODO: Destroy sound when that gets added
+
+			ActiveTurrets[self] = nil
 
 			if IsValid(SelfTbl.Motor) then
 				SelfTbl.Motor:ValidatePlacement()


### PR DESCRIPTION
Previous attempt at fixing turret stabilization resulted in acceleration effectively being entirely bypassed for stabilized turrets. This approach retains acceleration ramp up/down for rotating the turret towards its aim point, but bypasses acceleration when relevant for stabilizing the turret from what it's mounted onto.