### PR TITLE
Update turret control behavior for casemates

### DIFF
--- a/lua/acf/core/globals.lua
+++ b/lua/acf/core/globals.lua
@@ -390,6 +390,7 @@ do -- ACF global vars
 		acf_rack	= true
 	}
 	ACF.LightweightTurretMassLimit = 250	-- kg. Turrets at or under this carried mass can be controlled by a shared-parent Gunner, or a Lightweight Turret Controller, without needing to be mounted on it
+	ACF.CasemateArcLimit = 45	-- Degrees of total arc (MaxDeg - MinDeg) at or under which a shared-parent Gunner controls a turret at any mass, so casemate mounts don't need the gunner parented to the ring
 
 	ACF.CrewRepTimeBase 	= 3		-- Base time to replace a crew member
 	ACF.CrewRepDistToTime 	= 0.05 	-- Time it takes for crew to move one inch during replacement

--- a/lua/entities/acf_turret/init.lua
+++ b/lua/entities/acf_turret/init.lua
@@ -49,6 +49,10 @@ do -- Random timer crew stuff
 		if CrewParent == Turret:GetParent() then -- Shares a parent with the turret
 			local CarriedMass = (Turret.TurretData.TotalMass or 0) + (Turret.ACF.Mass or 0)
 			if CarriedMass <= ACF.LightweightTurretMassLimit then return true, true end
+
+			-- Casemates traverse too little to need a dedicated gunner station, so they cascade at any mass
+			if (Turret.MaxDeg - Turret.MinDeg) <= ACF.CasemateArcLimit then return true, true end
+
 			return true, false -- Controls, but no cascade to vertical drives
 		end
 

--- a/lua/entities/acf_turret_controller/init.lua
+++ b/lua/entities/acf_turret_controller/init.lua
@@ -151,6 +151,16 @@ do	-- Metamethods
 				return false
 			end
 
+			-- Overweight turrets keep the link but get no bonus, so the mass is rechecked here
+			-- every time rather than once at link time
+			if not self.IsRemote then
+				local CarriedMass = (Linked.TurretData and Linked.TurretData.TotalMass or 0) + (Linked.ACF and Linked.ACF.Mass or 0)
+				if CarriedMass > ACF.LightweightTurretMassLimit then
+					self:SetActive(false, "Turret is too heavy!")
+					return false
+				end
+			end
+
 			if self.Active == false then self:SetActive(true, "") end
 			return true
 		end
@@ -216,9 +226,6 @@ do	-- Lightweight Turret Controllers link to acf_turret directly, no crew involv
 		if ThisContraption ~= nil and TurretContraption ~= nil and ThisContraption ~= TurretContraption then
 			return false, "This controller and turret are not part of the same contraption."
 		end
-
-		local CarriedMass = (Turret.TurretData and Turret.TurretData.TotalMass or 0) + (Turret.ACF and Turret.ACF.Mass or 0)
-		if CarriedMass > ACF.LightweightTurretMassLimit then return false, "This turret is too heavy for a Lightweight Turret Controller." end
 
 		return true
 	end)


### PR DESCRIPTION
- Casemate turrets are now possible; cases where the gunner and turret share a parent, and the total arc of the turret is 45 degrees or less, permits control propagation to vertical drives of that turret

- Lightweight turret controllers no longer forcibly break or prevent a link to turrets when the turret cumulative mass is over the lightweight limit